### PR TITLE
expose scroll physics for message list view

### DIFF
--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -36,6 +36,7 @@ class MessageListView extends StatefulWidget {
   final bool textBeforeImage;
   final double avatarMaxSize;
   final BoxDecoration Function(ChatMessage, bool) messageDecorationBuilder;
+  final ScrollPhysics scrollPhysics;
 
   MessageListView({
     this.showLoadEarlierWidget,
@@ -74,6 +75,7 @@ class MessageListView extends StatefulWidget {
     this.messagePadding = const EdgeInsets.all(8.0),
     this.textBeforeImage = true,
     this.messageDecorationBuilder,
+    this.scrollPhysics = const AlwaysScrollableScrollPhysics(),
   });
 
   @override
@@ -138,6 +140,7 @@ class _MessageListViewState extends State<MessageListView> {
               children: [
                 ListView.builder(
                   controller: widget.scrollController,
+                  physics: widget.scrollPhysics,
                   keyboardDismissBehavior:
                       ScrollViewKeyboardDismissBehavior.onDrag,
                   shrinkWrap: true,


### PR DESCRIPTION
[ch124196](https://app.clubhouse.io/gloo/story/124196/fix-dashchat-fork-to-allow-for-scroll-physics)

setting scroll physics on the list view allows `RefreshIndicator` to pick up scroll events even when the content is not yet scrollable
https://stackoverflow.com/a/57520024/1411056


https://user-images.githubusercontent.com/6465955/120387015-9b60a180-c2e6-11eb-9b24-404c4dc9f2d0.mov

