### PR TITLE
Chore: Enable adding a widget to the top of Chat where we can inject anything we need

### DIFF
--- a/lib/src/chat_view.dart
+++ b/lib/src/chat_view.dart
@@ -117,11 +117,6 @@ class DashChat extends StatefulWidget {
   /// Should the messages be shown in reversed order.
   final bool inverted;
 
-  /// topOfMessagesWidget is the widget that will be placed above all messages
-  /// at the top of the scroll. This widget will appear even if there are no
-  /// messages yet.
-  final Widget topOfMessagesWidget;
-
   /// messageBuilder will override the the default chat container which uses
   /// and you will need to build complete message Widget it will not accept
   /// and include any other builder functions.
@@ -138,6 +133,11 @@ class DashChat extends StatefulWidget {
 
   /// dateBuilder will override the the default time text.
   final Widget Function(String) dateBuilder;
+
+  /// A Widget that will be shown at the top of the [MessageListView] like an
+  /// image or text you want above all the messages or above the input field
+  /// if no messages.
+  final Widget Function() messageListHeaderBuilder;
 
   /// A Widget that will be shown below the [MessageListView] like you can
   /// show a "tying..." at the end.
@@ -346,9 +346,9 @@ class DashChat extends StatefulWidget {
     this.showAvatarForEveryMessage = false,
     this.showUserAvatar = false,
     this.inverted = false,
-    this.topOfMessagesWidget,
     this.maxInputLength,
     this.parsePatterns = const <MatchText>[],
+    this.messageListHeaderBuilder,
     this.chatFooterBuilder,
     this.messageBuilder,
     this.inputFooterBuilder,
@@ -513,7 +513,7 @@ class DashChatState extends State<DashChat> {
                       dateFormat: widget.dateFormat,
                       timeFormat: widget.timeFormat,
                       inverted: widget.inverted,
-                      topOfMessagesWidget: widget.topOfMessagesWidget,
+                      messageListHeaderBuilder: widget.messageListHeaderBuilder,
                       showAvatarForEverMessage:
                           widget.showAvatarForEveryMessage,
                       onLongPressAvatar: widget.onLongPressAvatar,

--- a/lib/src/chat_view.dart
+++ b/lib/src/chat_view.dart
@@ -486,9 +486,15 @@ class DashChatState extends State<DashChat> {
             children: <Widget>[
               Column(
                 mainAxisAlignment: widget.shouldStartMessagesFromTop
-                    ? MainAxisAlignment.spaceBetween
+                    ? MainAxisAlignment.start
                     : MainAxisAlignment.end,
                 children: <Widget>[
+                  Container(
+                    height: 200,
+                    width: constraints.maxWidth,
+                    color: Colors.indigo,
+                    child: Text('Image goes here'),
+                  ),
                   MessageListView(
                       avatarMaxSize: widget.avatarMaxSize,
                       messagePadding: widget.messagePadding,

--- a/lib/src/chat_view.dart
+++ b/lib/src/chat_view.dart
@@ -117,6 +117,11 @@ class DashChat extends StatefulWidget {
   /// Should the messages be shown in reversed order.
   final bool inverted;
 
+  /// topOfMessagesWidget is the widget that will be placed above all messages
+  /// at the top of the scroll. This widget will appear even if there are no
+  /// messages yet.
+  final Image topOfMessagesWidget;
+
   /// messageBuilder will override the the default chat container which uses
   /// and you will need to build complete message Widget it will not accept
   /// and include any other builder functions.
@@ -341,6 +346,7 @@ class DashChat extends StatefulWidget {
     this.showAvatarForEveryMessage = false,
     this.showUserAvatar = false,
     this.inverted = false,
+    this.topOfMessagesWidget,
     this.maxInputLength,
     this.parsePatterns = const <MatchText>[],
     this.chatFooterBuilder,
@@ -507,6 +513,7 @@ class DashChatState extends State<DashChat> {
                       dateFormat: widget.dateFormat,
                       timeFormat: widget.timeFormat,
                       inverted: widget.inverted,
+                      topOfMessagesWidget: widget.topOfMessagesWidget,
                       showAvatarForEverMessage:
                           widget.showAvatarForEveryMessage,
                       onLongPressAvatar: widget.onLongPressAvatar,

--- a/lib/src/chat_view.dart
+++ b/lib/src/chat_view.dart
@@ -486,7 +486,7 @@ class DashChatState extends State<DashChat> {
             children: <Widget>[
               Column(
                 mainAxisAlignment: widget.shouldStartMessagesFromTop
-                    ? MainAxisAlignment.start
+                    ? MainAxisAlignment.spaceBetween
                     : MainAxisAlignment.end,
                 children: <Widget>[
                   MessageListView(

--- a/lib/src/chat_view.dart
+++ b/lib/src/chat_view.dart
@@ -558,10 +558,6 @@ class DashChatState extends State<DashChat> {
                               ],
                             ),
                     ),
-                  Container(
-                    height: 100,
-                    color: Colors.red,
-                  ),
                   if (widget.chatFooterBuilder != null)
                     widget.chatFooterBuilder(),
                   if (!widget.readOnly)

--- a/lib/src/chat_view.dart
+++ b/lib/src/chat_view.dart
@@ -489,44 +489,46 @@ class DashChatState extends State<DashChat> {
                     ? MainAxisAlignment.spaceBetween
                     : MainAxisAlignment.end,
                 children: <Widget>[
-                  MessageListView(
-                      avatarMaxSize: widget.avatarMaxSize,
-                      messagePadding: widget.messagePadding,
-                      constraints: constraints,
-                      shouldShowLoadEarlier: widget.shouldShowLoadEarlier,
-                      showLoadEarlierWidget: widget.showLoadEarlierWidget,
-                      onLoadEarlier: widget.onLoadEarlier,
-                      defaultLoadCallback: changeDefaultLoadMore,
-                      messageContainerPadding: widget.messageContainerPadding,
-                      scrollController: widget.scrollController != null
-                          ? widget.scrollController
-                          : scrollController,
-                      user: widget.user,
-                      messages: widget.messages,
-                      showUserAvatar: widget.showUserAvatar,
-                      dateFormat: widget.dateFormat,
-                      timeFormat: widget.timeFormat,
-                      inverted: widget.inverted,
-                      showAvatarForEverMessage:
-                          widget.showAvatarForEveryMessage,
-                      onLongPressAvatar: widget.onLongPressAvatar,
-                      onPressAvatar: widget.onPressAvatar,
-                      onLongPressMessage: widget.onLongPressMessage,
-                      avatarBuilder: widget.avatarBuilder,
-                      messageBuilder: widget.messageBuilder,
-                      messageTextBuilder: widget.messageTextBuilder,
-                      messageImageBuilder: widget.messageImageBuilder,
-                      messageTimeBuilder: widget.messageTimeBuilder,
-                      dateBuilder: widget.dateBuilder,
-                      messageContainerDecoration:
-                          widget.messageContainerDecoration,
-                      parsePatterns: widget.parsePatterns,
-                      changeVisible: changeVisible,
-                      visible: visible,
-                      showLoadMore: showLoadMore,
-                      messageButtonsBuilder: widget.messageButtonsBuilder,
-                      messageDecorationBuilder:
-                          widget.messageDecorationBuilder),
+                  SizedBox.expand(
+                    child: MessageListView(
+                        avatarMaxSize: widget.avatarMaxSize,
+                        messagePadding: widget.messagePadding,
+                        constraints: constraints,
+                        shouldShowLoadEarlier: widget.shouldShowLoadEarlier,
+                        showLoadEarlierWidget: widget.showLoadEarlierWidget,
+                        onLoadEarlier: widget.onLoadEarlier,
+                        defaultLoadCallback: changeDefaultLoadMore,
+                        messageContainerPadding: widget.messageContainerPadding,
+                        scrollController: widget.scrollController != null
+                            ? widget.scrollController
+                            : scrollController,
+                        user: widget.user,
+                        messages: widget.messages,
+                        showUserAvatar: widget.showUserAvatar,
+                        dateFormat: widget.dateFormat,
+                        timeFormat: widget.timeFormat,
+                        inverted: widget.inverted,
+                        showAvatarForEverMessage:
+                            widget.showAvatarForEveryMessage,
+                        onLongPressAvatar: widget.onLongPressAvatar,
+                        onPressAvatar: widget.onPressAvatar,
+                        onLongPressMessage: widget.onLongPressMessage,
+                        avatarBuilder: widget.avatarBuilder,
+                        messageBuilder: widget.messageBuilder,
+                        messageTextBuilder: widget.messageTextBuilder,
+                        messageImageBuilder: widget.messageImageBuilder,
+                        messageTimeBuilder: widget.messageTimeBuilder,
+                        dateBuilder: widget.dateBuilder,
+                        messageContainerDecoration:
+                            widget.messageContainerDecoration,
+                        parsePatterns: widget.parsePatterns,
+                        changeVisible: changeVisible,
+                        visible: visible,
+                        showLoadMore: showLoadMore,
+                        messageButtonsBuilder: widget.messageButtonsBuilder,
+                        messageDecorationBuilder:
+                            widget.messageDecorationBuilder),
+                  ),
                   if (widget.messages.length != 0 &&
                       widget.messages.last.user.uid != widget.user.uid &&
                       widget.messages.last.quickReplies != null)

--- a/lib/src/chat_view.dart
+++ b/lib/src/chat_view.dart
@@ -490,10 +490,15 @@ class DashChatState extends State<DashChat> {
                     : MainAxisAlignment.end,
                 children: <Widget>[
                   Container(
-                    height: 200,
+                    height: 300,
                     width: constraints.maxWidth,
                     color: Colors.indigo,
-                    child: Text('Image goes here'),
+                    child: Text(
+                      'Image goes here',
+                      style: TextStyle(
+                        color: Colors.white,
+                      ),
+                    ),
                   ),
                   MessageListView(
                       avatarMaxSize: widget.avatarMaxSize,

--- a/lib/src/chat_view.dart
+++ b/lib/src/chat_view.dart
@@ -558,6 +558,10 @@ class DashChatState extends State<DashChat> {
                               ],
                             ),
                     ),
+                  Container(
+                    height: 100,
+                    color: Colors.red,
+                  ),
                   if (widget.chatFooterBuilder != null)
                     widget.chatFooterBuilder(),
                   if (!widget.readOnly)

--- a/lib/src/chat_view.dart
+++ b/lib/src/chat_view.dart
@@ -489,17 +489,6 @@ class DashChatState extends State<DashChat> {
                     ? MainAxisAlignment.start
                     : MainAxisAlignment.end,
                 children: <Widget>[
-                  Container(
-                    height: 300,
-                    width: constraints.maxWidth,
-                    color: Colors.indigo,
-                    child: Text(
-                      'Image goes here',
-                      style: TextStyle(
-                        color: Colors.white,
-                      ),
-                    ),
-                  ),
                   MessageListView(
                       avatarMaxSize: widget.avatarMaxSize,
                       messagePadding: widget.messagePadding,

--- a/lib/src/chat_view.dart
+++ b/lib/src/chat_view.dart
@@ -120,7 +120,7 @@ class DashChat extends StatefulWidget {
   /// topOfMessagesWidget is the widget that will be placed above all messages
   /// at the top of the scroll. This widget will appear even if there are no
   /// messages yet.
-  final Image topOfMessagesWidget;
+  final Widget topOfMessagesWidget;
 
   /// messageBuilder will override the the default chat container which uses
   /// and you will need to build complete message Widget it will not accept

--- a/lib/src/chat_view.dart
+++ b/lib/src/chat_view.dart
@@ -489,46 +489,44 @@ class DashChatState extends State<DashChat> {
                     ? MainAxisAlignment.spaceBetween
                     : MainAxisAlignment.end,
                 children: <Widget>[
-                  SizedBox.expand(
-                    child: MessageListView(
-                        avatarMaxSize: widget.avatarMaxSize,
-                        messagePadding: widget.messagePadding,
-                        constraints: constraints,
-                        shouldShowLoadEarlier: widget.shouldShowLoadEarlier,
-                        showLoadEarlierWidget: widget.showLoadEarlierWidget,
-                        onLoadEarlier: widget.onLoadEarlier,
-                        defaultLoadCallback: changeDefaultLoadMore,
-                        messageContainerPadding: widget.messageContainerPadding,
-                        scrollController: widget.scrollController != null
-                            ? widget.scrollController
-                            : scrollController,
-                        user: widget.user,
-                        messages: widget.messages,
-                        showUserAvatar: widget.showUserAvatar,
-                        dateFormat: widget.dateFormat,
-                        timeFormat: widget.timeFormat,
-                        inverted: widget.inverted,
-                        showAvatarForEverMessage:
-                            widget.showAvatarForEveryMessage,
-                        onLongPressAvatar: widget.onLongPressAvatar,
-                        onPressAvatar: widget.onPressAvatar,
-                        onLongPressMessage: widget.onLongPressMessage,
-                        avatarBuilder: widget.avatarBuilder,
-                        messageBuilder: widget.messageBuilder,
-                        messageTextBuilder: widget.messageTextBuilder,
-                        messageImageBuilder: widget.messageImageBuilder,
-                        messageTimeBuilder: widget.messageTimeBuilder,
-                        dateBuilder: widget.dateBuilder,
-                        messageContainerDecoration:
-                            widget.messageContainerDecoration,
-                        parsePatterns: widget.parsePatterns,
-                        changeVisible: changeVisible,
-                        visible: visible,
-                        showLoadMore: showLoadMore,
-                        messageButtonsBuilder: widget.messageButtonsBuilder,
-                        messageDecorationBuilder:
-                            widget.messageDecorationBuilder),
-                  ),
+                  MessageListView(
+                      avatarMaxSize: widget.avatarMaxSize,
+                      messagePadding: widget.messagePadding,
+                      constraints: constraints,
+                      shouldShowLoadEarlier: widget.shouldShowLoadEarlier,
+                      showLoadEarlierWidget: widget.showLoadEarlierWidget,
+                      onLoadEarlier: widget.onLoadEarlier,
+                      defaultLoadCallback: changeDefaultLoadMore,
+                      messageContainerPadding: widget.messageContainerPadding,
+                      scrollController: widget.scrollController != null
+                          ? widget.scrollController
+                          : scrollController,
+                      user: widget.user,
+                      messages: widget.messages,
+                      showUserAvatar: widget.showUserAvatar,
+                      dateFormat: widget.dateFormat,
+                      timeFormat: widget.timeFormat,
+                      inverted: widget.inverted,
+                      showAvatarForEverMessage:
+                          widget.showAvatarForEveryMessage,
+                      onLongPressAvatar: widget.onLongPressAvatar,
+                      onPressAvatar: widget.onPressAvatar,
+                      onLongPressMessage: widget.onLongPressMessage,
+                      avatarBuilder: widget.avatarBuilder,
+                      messageBuilder: widget.messageBuilder,
+                      messageTextBuilder: widget.messageTextBuilder,
+                      messageImageBuilder: widget.messageImageBuilder,
+                      messageTimeBuilder: widget.messageTimeBuilder,
+                      dateBuilder: widget.dateBuilder,
+                      messageContainerDecoration:
+                          widget.messageContainerDecoration,
+                      parsePatterns: widget.parsePatterns,
+                      changeVisible: changeVisible,
+                      visible: visible,
+                      showLoadMore: showLoadMore,
+                      messageButtonsBuilder: widget.messageButtonsBuilder,
+                      messageDecorationBuilder:
+                          widget.messageDecorationBuilder),
                   if (widget.messages.length != 0 &&
                       widget.messages.last.user.uid != widget.user.uid &&
                       widget.messages.last.quickReplies != null)

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -140,7 +140,7 @@ class _MessageListViewState extends State<MessageListView> {
             child: Stack(
               alignment: AlignmentDirectional.topCenter,
               children: [
-                if (widget.topOfMessagesWidget != null)
+                if (itemCount == 0 && widget.topOfMessagesWidget != null)
                   widget.topOfMessagesWidget,
                 ListView.builder(
                   controller: widget.scrollController,
@@ -194,8 +194,8 @@ class _MessageListViewState extends State<MessageListView> {
                     return Align(
                       child: Column(
                         children: <Widget>[
-                          // if (last && widget.topOfMessagesWidget != null)
-                          //   widget.topOfMessagesWidget,
+                          if (last && widget.topOfMessagesWidget != null)
+                            widget.topOfMessagesWidget,
                           if (showCurrentDate)
                             DateBuilder(
                               date: currentDate,

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -138,6 +138,18 @@ class _MessageListViewState extends State<MessageListView> {
             child: Stack(
               alignment: AlignmentDirectional.topCenter,
               children: [
+                if (itemCount == 0)
+                  Container(
+                    height: 100,
+                    width: constraints.maxWidth,
+                    color: Colors.indigo,
+                    child: Text(
+                      'Image goes here',
+                      style: TextStyle(
+                        color: Colors.white,
+                      ),
+                    ),
+                  ),
                 ListView.builder(
                   controller: widget.scrollController,
                   physics: widget.scrollPhysics,
@@ -190,7 +202,7 @@ class _MessageListViewState extends State<MessageListView> {
                     return Align(
                       child: Column(
                         children: <Widget>[
-                          if (itemCount == 0 || first)
+                          if (last)
                             Container(
                               height: 100,
                               width: constraints.maxWidth,

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -140,7 +140,7 @@ class _MessageListViewState extends State<MessageListView> {
             child: Stack(
               alignment: AlignmentDirectional.topCenter,
               children: [
-                if (itemCount == 0 && widget.topOfMessagesWidget != null)
+                if (widget.topOfMessagesWidget != null)
                   widget.topOfMessagesWidget,
                 ListView.builder(
                   controller: widget.scrollController,
@@ -194,8 +194,8 @@ class _MessageListViewState extends State<MessageListView> {
                     return Align(
                       child: Column(
                         children: <Widget>[
-                          if (last && widget.topOfMessagesWidget != null)
-                            widget.topOfMessagesWidget,
+                          // if (last && widget.topOfMessagesWidget != null)
+                          //   widget.topOfMessagesWidget,
                           if (showCurrentDate)
                             DateBuilder(
                               date: currentDate,

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -123,92 +123,189 @@ class _MessageListViewState extends State<MessageListView> {
             maxHeight: MediaQuery.of(context).size.height,
             maxWidth: MediaQuery.of(context).size.width);
     final itemCount = widget.messages.length;
-    return Flexible(
-      child: IntrinsicHeight(
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            GestureDetector(
-              onTap: () {
-                final currentFocus = FocusScope.of(context);
-                if (!currentFocus.hasPrimaryFocus && currentFocus.hasFocus) {
-                  FocusManager.instance.primaryFocus.unfocus();
-                }
-              },
-              child: Padding(
-                padding: widget.messageContainerPadding,
-                child: NotificationListener<ScrollNotification>(
-                  onNotification: scrollNotificationFunc,
-                  child: Stack(
-                    alignment: AlignmentDirectional.topCenter,
-                    children: [
-                      ListView.builder(
-                        controller: widget.scrollController,
-                        physics: widget.scrollPhysics,
-                        keyboardDismissBehavior:
-                            ScrollViewKeyboardDismissBehavior.onDrag,
-                        shrinkWrap: true,
-                        reverse: widget.inverted,
-                        itemCount: itemCount,
-                        itemBuilder: (context, i) {
-                          bool showAvatar = shouldShowAvatar(i);
-                          bool first = i == 0;
-                          bool last = i == itemCount - 1;
+    return IntrinsicHeight(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          GestureDetector(
+            onTap: () {
+              final currentFocus = FocusScope.of(context);
+              if (!currentFocus.hasPrimaryFocus && currentFocus.hasFocus) {
+                FocusManager.instance.primaryFocus.unfocus();
+              }
+            },
+            child: Padding(
+              padding: widget.messageContainerPadding,
+              child: NotificationListener<ScrollNotification>(
+                onNotification: scrollNotificationFunc,
+                child: Stack(
+                  alignment: AlignmentDirectional.topCenter,
+                  children: [
+                    ListView.builder(
+                      controller: widget.scrollController,
+                      physics: widget.scrollPhysics,
+                      keyboardDismissBehavior:
+                          ScrollViewKeyboardDismissBehavior.onDrag,
+                      shrinkWrap: true,
+                      reverse: widget.inverted,
+                      itemCount: itemCount,
+                      itemBuilder: (context, i) {
+                        bool showAvatar = shouldShowAvatar(i);
+                        bool first = i == 0;
+                        bool last = i == itemCount - 1;
 
-                          DateTime currentDate = DateTime(
-                            widget.messages[i].createdAt.year,
-                            widget.messages[i].createdAt.month,
-                            widget.messages[i].createdAt.day,
+                        DateTime currentDate = DateTime(
+                          widget.messages[i].createdAt.year,
+                          widget.messages[i].createdAt.month,
+                          widget.messages[i].createdAt.day,
+                        );
+
+                        DateTime previousDate;
+                        if (i == 0) {
+                          previousDate = currentDate;
+                        } else {
+                          previousDate = DateTime(
+                            widget.messages[i - 1].createdAt.year,
+                            widget.messages[i - 1].createdAt.month,
+                            widget.messages[i - 1].createdAt.day,
                           );
-
-                          DateTime previousDate;
-                          if (i == 0) {
-                            previousDate = currentDate;
-                          } else {
-                            previousDate = DateTime(
-                              widget.messages[i - 1].createdAt.year,
-                              widget.messages[i - 1].createdAt.month,
-                              widget.messages[i - 1].createdAt.day,
-                            );
-                          }
-                          bool showCurrentDate = false;
-                          bool showPreviousDate = false;
-                          if (currentDate.difference(previousDate).inDays !=
-                              0) {
-                            if (widget.inverted) {
-                              showPreviousDate = true;
-                              if (last) {
-                                showCurrentDate = true;
-                              }
-                            } else {
+                        }
+                        bool showCurrentDate = false;
+                        bool showPreviousDate = false;
+                        if (currentDate.difference(previousDate).inDays != 0) {
+                          if (widget.inverted) {
+                            showPreviousDate = true;
+                            if (last) {
                               showCurrentDate = true;
-                              if (first) {
-                                showPreviousDate = true;
-                              }
                             }
-                          } else if (widget.inverted && last) {
+                          } else {
                             showCurrentDate = true;
-                          } else if (!widget.inverted && first) {
-                            showCurrentDate = true;
+                            if (first) {
+                              showPreviousDate = true;
+                            }
                           }
+                        } else if (widget.inverted && last) {
+                          showCurrentDate = true;
+                        } else if (!widget.inverted && first) {
+                          showCurrentDate = true;
+                        }
 
-                          return Align(
-                            child: Column(
-                              children: <Widget>[
-                                if (showCurrentDate)
-                                  DateBuilder(
-                                    date: currentDate,
-                                    customDateBuilder: widget.dateBuilder,
-                                    dateFormat: widget.dateFormat,
+                        return Align(
+                          child: Column(
+                            children: <Widget>[
+                              if (showCurrentDate)
+                                DateBuilder(
+                                  date: currentDate,
+                                  customDateBuilder: widget.dateBuilder,
+                                  dateFormat: widget.dateFormat,
+                                ),
+                              Row(
+                                mainAxisAlignment:
+                                    widget.messages[i].user.uid ==
+                                            widget.user.uid
+                                        ? MainAxisAlignment.end
+                                        : MainAxisAlignment.start,
+                                crossAxisAlignment: CrossAxisAlignment.end,
+                                children: <Widget>[
+                                  Padding(
+                                    padding: EdgeInsets.symmetric(
+                                      horizontal: constraints.maxWidth * 0.02,
+                                    ),
+                                    child: Opacity(
+                                      opacity:
+                                          (widget.showAvatarForEverMessage ||
+                                                      showAvatar) &&
+                                                  widget.messages[i].user.uid !=
+                                                      widget.user.uid
+                                              ? 1
+                                              : 0,
+                                      child: AvatarContainer(
+                                        user: widget.messages[i].user,
+                                        onPress: widget.onPressAvatar,
+                                        onLongPress: widget.onLongPressAvatar,
+                                        avatarBuilder: widget.avatarBuilder,
+                                        avatarMaxSize: widget.avatarMaxSize,
+                                      ),
+                                    ),
                                   ),
-                                Row(
-                                  mainAxisAlignment:
-                                      widget.messages[i].user.uid ==
-                                              widget.user.uid
-                                          ? MainAxisAlignment.end
-                                          : MainAxisAlignment.start,
-                                  crossAxisAlignment: CrossAxisAlignment.end,
-                                  children: <Widget>[
+                                  Expanded(
+                                    child: GestureDetector(
+                                      onLongPress: () {
+                                        if (widget.onLongPressMessage != null) {
+                                          widget.onLongPressMessage(
+                                              widget.messages[i]);
+                                        } else {
+                                          showBottomSheet(
+                                              context: context,
+                                              builder: (context) => Container(
+                                                    child: Column(
+                                                      mainAxisSize:
+                                                          MainAxisSize.min,
+                                                      children: <Widget>[
+                                                        ListTile(
+                                                          leading: Icon(Icons
+                                                              .content_copy),
+                                                          title: Text(
+                                                              "Copy to clipboard"),
+                                                          onTap: () {
+                                                            Clipboard.setData(
+                                                                ClipboardData(
+                                                                    text: widget
+                                                                        .messages[
+                                                                            i]
+                                                                        .text));
+                                                            Navigator.pop(
+                                                                context);
+                                                          },
+                                                        )
+                                                      ],
+                                                    ),
+                                                  ));
+                                        }
+                                      },
+                                      child: widget.messageBuilder != null
+                                          ? widget.messageBuilder(
+                                              widget.messages[i])
+                                          : Align(
+                                              alignment:
+                                                  widget.messages[i].user.uid ==
+                                                          widget.user.uid
+                                                      ? AlignmentDirectional
+                                                          .centerEnd
+                                                      : AlignmentDirectional
+                                                          .centerStart,
+                                              child: MessageContainer(
+                                                messagePadding:
+                                                    widget.messagePadding,
+                                                constraints: constraints,
+                                                isUser: widget
+                                                        .messages[i].user.uid ==
+                                                    widget.user.uid,
+                                                message: widget.messages[i],
+                                                timeFormat: widget.timeFormat,
+                                                messageImageBuilder:
+                                                    widget.messageImageBuilder,
+                                                messageTextBuilder:
+                                                    widget.messageTextBuilder,
+                                                messageTimeBuilder:
+                                                    widget.messageTimeBuilder,
+                                                messageContainerDecoration: widget
+                                                    .messageContainerDecoration,
+                                                parsePatterns:
+                                                    widget.parsePatterns,
+                                                buttons:
+                                                    widget.messages[i].buttons,
+                                                messageButtonsBuilder: widget
+                                                    .messageButtonsBuilder,
+                                                textBeforeImage:
+                                                    widget.textBeforeImage,
+                                                messageDecorationBuilder: widget
+                                                    .messageDecorationBuilder,
+                                              ),
+                                            ),
+                                    ),
+                                  ),
+                                  if (widget.showUserAvatar)
                                     Padding(
                                       padding: EdgeInsets.symmetric(
                                         horizontal: constraints.maxWidth * 0.02,
@@ -218,7 +315,7 @@ class _MessageListViewState extends State<MessageListView> {
                                             (widget.showAvatarForEverMessage ||
                                                         showAvatar) &&
                                                     widget.messages[i].user
-                                                            .uid !=
+                                                            .uid ==
                                                         widget.user.uid
                                                 ? 1
                                                 : 0,
@@ -230,147 +327,43 @@ class _MessageListViewState extends State<MessageListView> {
                                           avatarMaxSize: widget.avatarMaxSize,
                                         ),
                                       ),
+                                    )
+                                  else
+                                    SizedBox(
+                                      width: 10.0,
                                     ),
-                                    Expanded(
-                                      child: GestureDetector(
-                                        onLongPress: () {
-                                          if (widget.onLongPressMessage !=
-                                              null) {
-                                            widget.onLongPressMessage(
-                                                widget.messages[i]);
-                                          } else {
-                                            showBottomSheet(
-                                                context: context,
-                                                builder: (context) => Container(
-                                                      child: Column(
-                                                        mainAxisSize:
-                                                            MainAxisSize.min,
-                                                        children: <Widget>[
-                                                          ListTile(
-                                                            leading: Icon(Icons
-                                                                .content_copy),
-                                                            title: Text(
-                                                                "Copy to clipboard"),
-                                                            onTap: () {
-                                                              Clipboard.setData(
-                                                                  ClipboardData(
-                                                                      text: widget
-                                                                          .messages[
-                                                                              i]
-                                                                          .text));
-                                                              Navigator.pop(
-                                                                  context);
-                                                            },
-                                                          )
-                                                        ],
-                                                      ),
-                                                    ));
-                                          }
-                                        },
-                                        child: widget.messageBuilder != null
-                                            ? widget.messageBuilder(
-                                                widget.messages[i])
-                                            : Align(
-                                                alignment: widget.messages[i]
-                                                            .user.uid ==
-                                                        widget.user.uid
-                                                    ? AlignmentDirectional
-                                                        .centerEnd
-                                                    : AlignmentDirectional
-                                                        .centerStart,
-                                                child: MessageContainer(
-                                                  messagePadding:
-                                                      widget.messagePadding,
-                                                  constraints: constraints,
-                                                  isUser: widget.messages[i]
-                                                          .user.uid ==
-                                                      widget.user.uid,
-                                                  message: widget.messages[i],
-                                                  timeFormat: widget.timeFormat,
-                                                  messageImageBuilder: widget
-                                                      .messageImageBuilder,
-                                                  messageTextBuilder:
-                                                      widget.messageTextBuilder,
-                                                  messageTimeBuilder:
-                                                      widget.messageTimeBuilder,
-                                                  messageContainerDecoration: widget
-                                                      .messageContainerDecoration,
-                                                  parsePatterns:
-                                                      widget.parsePatterns,
-                                                  buttons: widget
-                                                      .messages[i].buttons,
-                                                  messageButtonsBuilder: widget
-                                                      .messageButtonsBuilder,
-                                                  textBeforeImage:
-                                                      widget.textBeforeImage,
-                                                  messageDecorationBuilder: widget
-                                                      .messageDecorationBuilder,
-                                                ),
-                                              ),
-                                      ),
-                                    ),
-                                    if (widget.showUserAvatar)
-                                      Padding(
-                                        padding: EdgeInsets.symmetric(
-                                          horizontal:
-                                              constraints.maxWidth * 0.02,
-                                        ),
-                                        child: Opacity(
-                                          opacity:
-                                              (widget.showAvatarForEverMessage ||
-                                                          showAvatar) &&
-                                                      widget.messages[i].user
-                                                              .uid ==
-                                                          widget.user.uid
-                                                  ? 1
-                                                  : 0,
-                                          child: AvatarContainer(
-                                            user: widget.messages[i].user,
-                                            onPress: widget.onPressAvatar,
-                                            onLongPress:
-                                                widget.onLongPressAvatar,
-                                            avatarBuilder: widget.avatarBuilder,
-                                            avatarMaxSize: widget.avatarMaxSize,
-                                          ),
-                                        ),
-                                      )
-                                    else
-                                      SizedBox(
-                                        width: 10.0,
-                                      ),
-                                  ],
-                                ),
-                                if (showPreviousDate)
-                                  DateBuilder(
-                                    date: previousDate,
-                                    customDateBuilder: widget.dateBuilder,
-                                    dateFormat: widget.dateFormat,
-                                  ),
-                              ],
-                            ),
-                          );
-                        },
-                      ),
-                      Container(
-                        height: 100.0,
-                      ),
-                      AnimatedPositioned(
-                        top: widget.showLoadMore ? 8.0 : -50.0,
-                        duration: Duration(milliseconds: 200),
-                        child: widget.showLoadEarlierWidget != null
-                            ? widget.showLoadEarlierWidget()
-                            : LoadEarlierWidget(
-                                onLoadEarlier: widget.onLoadEarlier,
-                                defaultLoadCallback: widget.defaultLoadCallback,
+                                ],
                               ),
-                      ),
-                    ],
-                  ),
+                              if (showPreviousDate)
+                                DateBuilder(
+                                  date: previousDate,
+                                  customDateBuilder: widget.dateBuilder,
+                                  dateFormat: widget.dateFormat,
+                                ),
+                            ],
+                          ),
+                        );
+                      },
+                    ),
+                    Container(
+                      height: 100.0,
+                    ),
+                    AnimatedPositioned(
+                      top: widget.showLoadMore ? 8.0 : -50.0,
+                      duration: Duration(milliseconds: 200),
+                      child: widget.showLoadEarlierWidget != null
+                          ? widget.showLoadEarlierWidget()
+                          : LoadEarlierWidget(
+                              onLoadEarlier: widget.onLoadEarlier,
+                              defaultLoadCallback: widget.defaultLoadCallback,
+                            ),
+                    ),
+                  ],
                 ),
               ),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -145,7 +145,7 @@ class _MessageListViewState extends State<MessageListView> {
                     physics: widget.scrollPhysics,
                     keyboardDismissBehavior:
                         ScrollViewKeyboardDismissBehavior.onDrag,
-                    shrinkWrap: false,
+                    shrinkWrap: true,
                     reverse: widget.inverted,
                     itemCount: itemCount,
                     itemBuilder: (context, i) {

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -124,23 +124,23 @@ class _MessageListViewState extends State<MessageListView> {
             maxWidth: MediaQuery.of(context).size.width);
     final itemCount = widget.messages.length;
     return Flexible(
-      child: Container(
-        color: Colors.red,
-        child: GestureDetector(
-          onTap: () {
-            final currentFocus = FocusScope.of(context);
-            if (!currentFocus.hasPrimaryFocus && currentFocus.hasFocus) {
-              FocusManager.instance.primaryFocus.unfocus();
-            }
-          },
-          child: Padding(
-            padding: widget.messageContainerPadding,
-            child: NotificationListener<ScrollNotification>(
-              onNotification: scrollNotificationFunc,
-              child: Stack(
-                alignment: AlignmentDirectional.topCenter,
-                children: [
-                  ListView.builder(
+      child: GestureDetector(
+        onTap: () {
+          final currentFocus = FocusScope.of(context);
+          if (!currentFocus.hasPrimaryFocus && currentFocus.hasFocus) {
+            FocusManager.instance.primaryFocus.unfocus();
+          }
+        },
+        child: Padding(
+          padding: widget.messageContainerPadding,
+          child: NotificationListener<ScrollNotification>(
+            onNotification: scrollNotificationFunc,
+            child: Stack(
+              alignment: AlignmentDirectional.topCenter,
+              children: [
+                Container(
+                  color: Colors.red,
+                  child: ListView.builder(
                     controller: widget.scrollController,
                     physics: widget.scrollPhysics,
                     keyboardDismissBehavior:
@@ -340,21 +340,21 @@ class _MessageListViewState extends State<MessageListView> {
                       );
                     },
                   ),
-                  Container(
-                    height: 100.0,
-                  ),
-                  AnimatedPositioned(
-                    top: widget.showLoadMore ? 8.0 : -50.0,
-                    duration: Duration(milliseconds: 200),
-                    child: widget.showLoadEarlierWidget != null
-                        ? widget.showLoadEarlierWidget()
-                        : LoadEarlierWidget(
-                            onLoadEarlier: widget.onLoadEarlier,
-                            defaultLoadCallback: widget.defaultLoadCallback,
-                          ),
-                  ),
-                ],
-              ),
+                ),
+                Container(
+                  height: 100.0,
+                ),
+                AnimatedPositioned(
+                  top: widget.showLoadMore ? 8.0 : -50.0,
+                  duration: Duration(milliseconds: 200),
+                  child: widget.showLoadEarlierWidget != null
+                      ? widget.showLoadEarlierWidget()
+                      : LoadEarlierWidget(
+                          onLoadEarlier: widget.onLoadEarlier,
+                          defaultLoadCallback: widget.defaultLoadCallback,
+                        ),
+                ),
+              ],
             ),
           ),
         ),

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -190,6 +190,17 @@ class _MessageListViewState extends State<MessageListView> {
                     return Align(
                       child: Column(
                         children: <Widget>[
+                          Container(
+                            height: 100,
+                            width: constraints.maxWidth,
+                            color: Colors.indigo,
+                            child: Text(
+                              'Image goes here',
+                              style: TextStyle(
+                                color: Colors.white,
+                              ),
+                            ),
+                          ),
                           if (showCurrentDate)
                             DateBuilder(
                               date: currentDate,

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -126,90 +126,187 @@ class _MessageListViewState extends State<MessageListView> {
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
       children: [
-        Flexible(
-          child: GestureDetector(
-            onTap: () {
-              final currentFocus = FocusScope.of(context);
-              if (!currentFocus.hasPrimaryFocus && currentFocus.hasFocus) {
-                FocusManager.instance.primaryFocus.unfocus();
-              }
-            },
-            child: Padding(
-              padding: widget.messageContainerPadding,
-              child: NotificationListener<ScrollNotification>(
-                onNotification: scrollNotificationFunc,
-                child: Stack(
-                  alignment: AlignmentDirectional.topCenter,
-                  children: [
-                    Container(
-                      color: Colors.red,
-                      child: ListView.builder(
-                        controller: widget.scrollController,
-                        physics: widget.scrollPhysics,
-                        keyboardDismissBehavior:
-                            ScrollViewKeyboardDismissBehavior.onDrag,
-                        shrinkWrap: false,
-                        reverse: widget.inverted,
-                        itemCount: itemCount,
-                        itemBuilder: (context, i) {
-                          bool showAvatar = shouldShowAvatar(i);
-                          bool first = i == 0;
-                          bool last = i == itemCount - 1;
+        GestureDetector(
+          onTap: () {
+            final currentFocus = FocusScope.of(context);
+            if (!currentFocus.hasPrimaryFocus && currentFocus.hasFocus) {
+              FocusManager.instance.primaryFocus.unfocus();
+            }
+          },
+          child: Padding(
+            padding: widget.messageContainerPadding,
+            child: NotificationListener<ScrollNotification>(
+              onNotification: scrollNotificationFunc,
+              child: Stack(
+                alignment: AlignmentDirectional.topCenter,
+                children: [
+                  Container(
+                    color: Colors.red,
+                    child: ListView.builder(
+                      controller: widget.scrollController,
+                      physics: widget.scrollPhysics,
+                      keyboardDismissBehavior:
+                          ScrollViewKeyboardDismissBehavior.onDrag,
+                      shrinkWrap: false,
+                      reverse: widget.inverted,
+                      itemCount: itemCount,
+                      itemBuilder: (context, i) {
+                        bool showAvatar = shouldShowAvatar(i);
+                        bool first = i == 0;
+                        bool last = i == itemCount - 1;
 
-                          DateTime currentDate = DateTime(
-                            widget.messages[i].createdAt.year,
-                            widget.messages[i].createdAt.month,
-                            widget.messages[i].createdAt.day,
+                        DateTime currentDate = DateTime(
+                          widget.messages[i].createdAt.year,
+                          widget.messages[i].createdAt.month,
+                          widget.messages[i].createdAt.day,
+                        );
+
+                        DateTime previousDate;
+                        if (i == 0) {
+                          previousDate = currentDate;
+                        } else {
+                          previousDate = DateTime(
+                            widget.messages[i - 1].createdAt.year,
+                            widget.messages[i - 1].createdAt.month,
+                            widget.messages[i - 1].createdAt.day,
                           );
-
-                          DateTime previousDate;
-                          if (i == 0) {
-                            previousDate = currentDate;
-                          } else {
-                            previousDate = DateTime(
-                              widget.messages[i - 1].createdAt.year,
-                              widget.messages[i - 1].createdAt.month,
-                              widget.messages[i - 1].createdAt.day,
-                            );
-                          }
-                          bool showCurrentDate = false;
-                          bool showPreviousDate = false;
-                          if (currentDate.difference(previousDate).inDays !=
-                              0) {
-                            if (widget.inverted) {
-                              showPreviousDate = true;
-                              if (last) {
-                                showCurrentDate = true;
-                              }
-                            } else {
+                        }
+                        bool showCurrentDate = false;
+                        bool showPreviousDate = false;
+                        if (currentDate.difference(previousDate).inDays != 0) {
+                          if (widget.inverted) {
+                            showPreviousDate = true;
+                            if (last) {
                               showCurrentDate = true;
-                              if (first) {
-                                showPreviousDate = true;
-                              }
                             }
-                          } else if (widget.inverted && last) {
+                          } else {
                             showCurrentDate = true;
-                          } else if (!widget.inverted && first) {
-                            showCurrentDate = true;
+                            if (first) {
+                              showPreviousDate = true;
+                            }
                           }
+                        } else if (widget.inverted && last) {
+                          showCurrentDate = true;
+                        } else if (!widget.inverted && first) {
+                          showCurrentDate = true;
+                        }
 
-                          return Align(
-                            child: Column(
-                              children: <Widget>[
-                                if (showCurrentDate)
-                                  DateBuilder(
-                                    date: currentDate,
-                                    customDateBuilder: widget.dateBuilder,
-                                    dateFormat: widget.dateFormat,
+                        return Align(
+                          child: Column(
+                            children: <Widget>[
+                              if (showCurrentDate)
+                                DateBuilder(
+                                  date: currentDate,
+                                  customDateBuilder: widget.dateBuilder,
+                                  dateFormat: widget.dateFormat,
+                                ),
+                              Row(
+                                mainAxisAlignment:
+                                    widget.messages[i].user.uid ==
+                                            widget.user.uid
+                                        ? MainAxisAlignment.end
+                                        : MainAxisAlignment.start,
+                                crossAxisAlignment: CrossAxisAlignment.end,
+                                children: <Widget>[
+                                  Padding(
+                                    padding: EdgeInsets.symmetric(
+                                      horizontal: constraints.maxWidth * 0.02,
+                                    ),
+                                    child: Opacity(
+                                      opacity:
+                                          (widget.showAvatarForEverMessage ||
+                                                      showAvatar) &&
+                                                  widget.messages[i].user.uid !=
+                                                      widget.user.uid
+                                              ? 1
+                                              : 0,
+                                      child: AvatarContainer(
+                                        user: widget.messages[i].user,
+                                        onPress: widget.onPressAvatar,
+                                        onLongPress: widget.onLongPressAvatar,
+                                        avatarBuilder: widget.avatarBuilder,
+                                        avatarMaxSize: widget.avatarMaxSize,
+                                      ),
+                                    ),
                                   ),
-                                Row(
-                                  mainAxisAlignment:
-                                      widget.messages[i].user.uid ==
-                                              widget.user.uid
-                                          ? MainAxisAlignment.end
-                                          : MainAxisAlignment.start,
-                                  crossAxisAlignment: CrossAxisAlignment.end,
-                                  children: <Widget>[
+                                  Expanded(
+                                    child: GestureDetector(
+                                      onLongPress: () {
+                                        if (widget.onLongPressMessage != null) {
+                                          widget.onLongPressMessage(
+                                              widget.messages[i]);
+                                        } else {
+                                          showBottomSheet(
+                                              context: context,
+                                              builder: (context) => Container(
+                                                    child: Column(
+                                                      mainAxisSize:
+                                                          MainAxisSize.min,
+                                                      children: <Widget>[
+                                                        ListTile(
+                                                          leading: Icon(Icons
+                                                              .content_copy),
+                                                          title: Text(
+                                                              "Copy to clipboard"),
+                                                          onTap: () {
+                                                            Clipboard.setData(
+                                                                ClipboardData(
+                                                                    text: widget
+                                                                        .messages[
+                                                                            i]
+                                                                        .text));
+                                                            Navigator.pop(
+                                                                context);
+                                                          },
+                                                        )
+                                                      ],
+                                                    ),
+                                                  ));
+                                        }
+                                      },
+                                      child: widget.messageBuilder != null
+                                          ? widget.messageBuilder(
+                                              widget.messages[i])
+                                          : Align(
+                                              alignment:
+                                                  widget.messages[i].user.uid ==
+                                                          widget.user.uid
+                                                      ? AlignmentDirectional
+                                                          .centerEnd
+                                                      : AlignmentDirectional
+                                                          .centerStart,
+                                              child: MessageContainer(
+                                                messagePadding:
+                                                    widget.messagePadding,
+                                                constraints: constraints,
+                                                isUser: widget
+                                                        .messages[i].user.uid ==
+                                                    widget.user.uid,
+                                                message: widget.messages[i],
+                                                timeFormat: widget.timeFormat,
+                                                messageImageBuilder:
+                                                    widget.messageImageBuilder,
+                                                messageTextBuilder:
+                                                    widget.messageTextBuilder,
+                                                messageTimeBuilder:
+                                                    widget.messageTimeBuilder,
+                                                messageContainerDecoration: widget
+                                                    .messageContainerDecoration,
+                                                parsePatterns:
+                                                    widget.parsePatterns,
+                                                buttons:
+                                                    widget.messages[i].buttons,
+                                                messageButtonsBuilder: widget
+                                                    .messageButtonsBuilder,
+                                                textBeforeImage:
+                                                    widget.textBeforeImage,
+                                                messageDecorationBuilder: widget
+                                                    .messageDecorationBuilder,
+                                              ),
+                                            ),
+                                    ),
+                                  ),
+                                  if (widget.showUserAvatar)
                                     Padding(
                                       padding: EdgeInsets.symmetric(
                                         horizontal: constraints.maxWidth * 0.02,
@@ -219,7 +316,7 @@ class _MessageListViewState extends State<MessageListView> {
                                             (widget.showAvatarForEverMessage ||
                                                         showAvatar) &&
                                                     widget.messages[i].user
-                                                            .uid !=
+                                                            .uid ==
                                                         widget.user.uid
                                                 ? 1
                                                 : 0,
@@ -231,143 +328,39 @@ class _MessageListViewState extends State<MessageListView> {
                                           avatarMaxSize: widget.avatarMaxSize,
                                         ),
                                       ),
+                                    )
+                                  else
+                                    SizedBox(
+                                      width: 10.0,
                                     ),
-                                    Expanded(
-                                      child: GestureDetector(
-                                        onLongPress: () {
-                                          if (widget.onLongPressMessage !=
-                                              null) {
-                                            widget.onLongPressMessage(
-                                                widget.messages[i]);
-                                          } else {
-                                            showBottomSheet(
-                                                context: context,
-                                                builder: (context) => Container(
-                                                      child: Column(
-                                                        mainAxisSize:
-                                                            MainAxisSize.min,
-                                                        children: <Widget>[
-                                                          ListTile(
-                                                            leading: Icon(Icons
-                                                                .content_copy),
-                                                            title: Text(
-                                                                "Copy to clipboard"),
-                                                            onTap: () {
-                                                              Clipboard.setData(
-                                                                  ClipboardData(
-                                                                      text: widget
-                                                                          .messages[
-                                                                              i]
-                                                                          .text));
-                                                              Navigator.pop(
-                                                                  context);
-                                                            },
-                                                          )
-                                                        ],
-                                                      ),
-                                                    ));
-                                          }
-                                        },
-                                        child: widget.messageBuilder != null
-                                            ? widget.messageBuilder(
-                                                widget.messages[i])
-                                            : Align(
-                                                alignment: widget.messages[i]
-                                                            .user.uid ==
-                                                        widget.user.uid
-                                                    ? AlignmentDirectional
-                                                        .centerEnd
-                                                    : AlignmentDirectional
-                                                        .centerStart,
-                                                child: MessageContainer(
-                                                  messagePadding:
-                                                      widget.messagePadding,
-                                                  constraints: constraints,
-                                                  isUser: widget.messages[i]
-                                                          .user.uid ==
-                                                      widget.user.uid,
-                                                  message: widget.messages[i],
-                                                  timeFormat: widget.timeFormat,
-                                                  messageImageBuilder: widget
-                                                      .messageImageBuilder,
-                                                  messageTextBuilder:
-                                                      widget.messageTextBuilder,
-                                                  messageTimeBuilder:
-                                                      widget.messageTimeBuilder,
-                                                  messageContainerDecoration: widget
-                                                      .messageContainerDecoration,
-                                                  parsePatterns:
-                                                      widget.parsePatterns,
-                                                  buttons: widget
-                                                      .messages[i].buttons,
-                                                  messageButtonsBuilder: widget
-                                                      .messageButtonsBuilder,
-                                                  textBeforeImage:
-                                                      widget.textBeforeImage,
-                                                  messageDecorationBuilder: widget
-                                                      .messageDecorationBuilder,
-                                                ),
-                                              ),
-                                      ),
-                                    ),
-                                    if (widget.showUserAvatar)
-                                      Padding(
-                                        padding: EdgeInsets.symmetric(
-                                          horizontal:
-                                              constraints.maxWidth * 0.02,
-                                        ),
-                                        child: Opacity(
-                                          opacity:
-                                              (widget.showAvatarForEverMessage ||
-                                                          showAvatar) &&
-                                                      widget.messages[i].user
-                                                              .uid ==
-                                                          widget.user.uid
-                                                  ? 1
-                                                  : 0,
-                                          child: AvatarContainer(
-                                            user: widget.messages[i].user,
-                                            onPress: widget.onPressAvatar,
-                                            onLongPress:
-                                                widget.onLongPressAvatar,
-                                            avatarBuilder: widget.avatarBuilder,
-                                            avatarMaxSize: widget.avatarMaxSize,
-                                          ),
-                                        ),
-                                      )
-                                    else
-                                      SizedBox(
-                                        width: 10.0,
-                                      ),
-                                  ],
+                                ],
+                              ),
+                              if (showPreviousDate)
+                                DateBuilder(
+                                  date: previousDate,
+                                  customDateBuilder: widget.dateBuilder,
+                                  dateFormat: widget.dateFormat,
                                 ),
-                                if (showPreviousDate)
-                                  DateBuilder(
-                                    date: previousDate,
-                                    customDateBuilder: widget.dateBuilder,
-                                    dateFormat: widget.dateFormat,
-                                  ),
-                              ],
-                            ),
-                          );
-                        },
-                      ),
+                            ],
+                          ),
+                        );
+                      },
                     ),
-                    Container(
-                      height: 100.0,
-                    ),
-                    AnimatedPositioned(
-                      top: widget.showLoadMore ? 8.0 : -50.0,
-                      duration: Duration(milliseconds: 200),
-                      child: widget.showLoadEarlierWidget != null
-                          ? widget.showLoadEarlierWidget()
-                          : LoadEarlierWidget(
-                              onLoadEarlier: widget.onLoadEarlier,
-                              defaultLoadCallback: widget.defaultLoadCallback,
-                            ),
-                    ),
-                  ],
-                ),
+                  ),
+                  Container(
+                    height: 100.0,
+                  ),
+                  AnimatedPositioned(
+                    top: widget.showLoadMore ? 8.0 : -50.0,
+                    duration: Duration(milliseconds: 200),
+                    child: widget.showLoadEarlierWidget != null
+                        ? widget.showLoadEarlierWidget()
+                        : LoadEarlierWidget(
+                            onLoadEarlier: widget.onLoadEarlier,
+                            defaultLoadCallback: widget.defaultLoadCallback,
+                          ),
+                  ),
+                ],
               ),
             ),
           ),

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -127,185 +127,89 @@ class _MessageListViewState extends State<MessageListView> {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          GestureDetector(
-            onTap: () {
-              final currentFocus = FocusScope.of(context);
-              if (!currentFocus.hasPrimaryFocus && currentFocus.hasFocus) {
-                FocusManager.instance.primaryFocus.unfocus();
-              }
-            },
-            child: Padding(
-              padding: widget.messageContainerPadding,
-              child: NotificationListener<ScrollNotification>(
-                onNotification: scrollNotificationFunc,
-                child: Stack(
-                  alignment: AlignmentDirectional.topCenter,
-                  children: [
-                    ListView.builder(
-                      controller: widget.scrollController,
-                      physics: widget.scrollPhysics,
-                      keyboardDismissBehavior:
-                          ScrollViewKeyboardDismissBehavior.onDrag,
-                      shrinkWrap: true,
-                      reverse: widget.inverted,
-                      itemCount: itemCount,
-                      itemBuilder: (context, i) {
-                        bool showAvatar = shouldShowAvatar(i);
-                        bool first = i == 0;
-                        bool last = i == itemCount - 1;
+          Container(
+            color: Colors.red,
+            child: GestureDetector(
+              onTap: () {
+                final currentFocus = FocusScope.of(context);
+                if (!currentFocus.hasPrimaryFocus && currentFocus.hasFocus) {
+                  FocusManager.instance.primaryFocus.unfocus();
+                }
+              },
+              child: Padding(
+                padding: widget.messageContainerPadding,
+                child: NotificationListener<ScrollNotification>(
+                  onNotification: scrollNotificationFunc,
+                  child: Stack(
+                    alignment: AlignmentDirectional.topCenter,
+                    children: [
+                      ListView.builder(
+                        controller: widget.scrollController,
+                        physics: widget.scrollPhysics,
+                        keyboardDismissBehavior:
+                            ScrollViewKeyboardDismissBehavior.onDrag,
+                        shrinkWrap: true,
+                        reverse: widget.inverted,
+                        itemCount: itemCount,
+                        itemBuilder: (context, i) {
+                          bool showAvatar = shouldShowAvatar(i);
+                          bool first = i == 0;
+                          bool last = i == itemCount - 1;
 
-                        DateTime currentDate = DateTime(
-                          widget.messages[i].createdAt.year,
-                          widget.messages[i].createdAt.month,
-                          widget.messages[i].createdAt.day,
-                        );
-
-                        DateTime previousDate;
-                        if (i == 0) {
-                          previousDate = currentDate;
-                        } else {
-                          previousDate = DateTime(
-                            widget.messages[i - 1].createdAt.year,
-                            widget.messages[i - 1].createdAt.month,
-                            widget.messages[i - 1].createdAt.day,
+                          DateTime currentDate = DateTime(
+                            widget.messages[i].createdAt.year,
+                            widget.messages[i].createdAt.month,
+                            widget.messages[i].createdAt.day,
                           );
-                        }
-                        bool showCurrentDate = false;
-                        bool showPreviousDate = false;
-                        if (currentDate.difference(previousDate).inDays != 0) {
-                          if (widget.inverted) {
-                            showPreviousDate = true;
-                            if (last) {
-                              showCurrentDate = true;
-                            }
-                          } else {
-                            showCurrentDate = true;
-                            if (first) {
-                              showPreviousDate = true;
-                            }
-                          }
-                        } else if (widget.inverted && last) {
-                          showCurrentDate = true;
-                        } else if (!widget.inverted && first) {
-                          showCurrentDate = true;
-                        }
 
-                        return Align(
-                          child: Column(
-                            children: <Widget>[
-                              if (showCurrentDate)
-                                DateBuilder(
-                                  date: currentDate,
-                                  customDateBuilder: widget.dateBuilder,
-                                  dateFormat: widget.dateFormat,
-                                ),
-                              Row(
-                                mainAxisAlignment:
-                                    widget.messages[i].user.uid ==
-                                            widget.user.uid
-                                        ? MainAxisAlignment.end
-                                        : MainAxisAlignment.start,
-                                crossAxisAlignment: CrossAxisAlignment.end,
-                                children: <Widget>[
-                                  Padding(
-                                    padding: EdgeInsets.symmetric(
-                                      horizontal: constraints.maxWidth * 0.02,
-                                    ),
-                                    child: Opacity(
-                                      opacity:
-                                          (widget.showAvatarForEverMessage ||
-                                                      showAvatar) &&
-                                                  widget.messages[i].user.uid !=
-                                                      widget.user.uid
-                                              ? 1
-                                              : 0,
-                                      child: AvatarContainer(
-                                        user: widget.messages[i].user,
-                                        onPress: widget.onPressAvatar,
-                                        onLongPress: widget.onLongPressAvatar,
-                                        avatarBuilder: widget.avatarBuilder,
-                                        avatarMaxSize: widget.avatarMaxSize,
-                                      ),
-                                    ),
+                          DateTime previousDate;
+                          if (i == 0) {
+                            previousDate = currentDate;
+                          } else {
+                            previousDate = DateTime(
+                              widget.messages[i - 1].createdAt.year,
+                              widget.messages[i - 1].createdAt.month,
+                              widget.messages[i - 1].createdAt.day,
+                            );
+                          }
+                          bool showCurrentDate = false;
+                          bool showPreviousDate = false;
+                          if (currentDate.difference(previousDate).inDays !=
+                              0) {
+                            if (widget.inverted) {
+                              showPreviousDate = true;
+                              if (last) {
+                                showCurrentDate = true;
+                              }
+                            } else {
+                              showCurrentDate = true;
+                              if (first) {
+                                showPreviousDate = true;
+                              }
+                            }
+                          } else if (widget.inverted && last) {
+                            showCurrentDate = true;
+                          } else if (!widget.inverted && first) {
+                            showCurrentDate = true;
+                          }
+
+                          return Align(
+                            child: Column(
+                              children: <Widget>[
+                                if (showCurrentDate)
+                                  DateBuilder(
+                                    date: currentDate,
+                                    customDateBuilder: widget.dateBuilder,
+                                    dateFormat: widget.dateFormat,
                                   ),
-                                  Expanded(
-                                    child: GestureDetector(
-                                      onLongPress: () {
-                                        if (widget.onLongPressMessage != null) {
-                                          widget.onLongPressMessage(
-                                              widget.messages[i]);
-                                        } else {
-                                          showBottomSheet(
-                                              context: context,
-                                              builder: (context) => Container(
-                                                    child: Column(
-                                                      mainAxisSize:
-                                                          MainAxisSize.min,
-                                                      children: <Widget>[
-                                                        ListTile(
-                                                          leading: Icon(Icons
-                                                              .content_copy),
-                                                          title: Text(
-                                                              "Copy to clipboard"),
-                                                          onTap: () {
-                                                            Clipboard.setData(
-                                                                ClipboardData(
-                                                                    text: widget
-                                                                        .messages[
-                                                                            i]
-                                                                        .text));
-                                                            Navigator.pop(
-                                                                context);
-                                                          },
-                                                        )
-                                                      ],
-                                                    ),
-                                                  ));
-                                        }
-                                      },
-                                      child: widget.messageBuilder != null
-                                          ? widget.messageBuilder(
-                                              widget.messages[i])
-                                          : Align(
-                                              alignment:
-                                                  widget.messages[i].user.uid ==
-                                                          widget.user.uid
-                                                      ? AlignmentDirectional
-                                                          .centerEnd
-                                                      : AlignmentDirectional
-                                                          .centerStart,
-                                              child: MessageContainer(
-                                                messagePadding:
-                                                    widget.messagePadding,
-                                                constraints: constraints,
-                                                isUser: widget
-                                                        .messages[i].user.uid ==
-                                                    widget.user.uid,
-                                                message: widget.messages[i],
-                                                timeFormat: widget.timeFormat,
-                                                messageImageBuilder:
-                                                    widget.messageImageBuilder,
-                                                messageTextBuilder:
-                                                    widget.messageTextBuilder,
-                                                messageTimeBuilder:
-                                                    widget.messageTimeBuilder,
-                                                messageContainerDecoration: widget
-                                                    .messageContainerDecoration,
-                                                parsePatterns:
-                                                    widget.parsePatterns,
-                                                buttons:
-                                                    widget.messages[i].buttons,
-                                                messageButtonsBuilder: widget
-                                                    .messageButtonsBuilder,
-                                                textBeforeImage:
-                                                    widget.textBeforeImage,
-                                                messageDecorationBuilder: widget
-                                                    .messageDecorationBuilder,
-                                              ),
-                                            ),
-                                    ),
-                                  ),
-                                  if (widget.showUserAvatar)
+                                Row(
+                                  mainAxisAlignment:
+                                      widget.messages[i].user.uid ==
+                                              widget.user.uid
+                                          ? MainAxisAlignment.end
+                                          : MainAxisAlignment.start,
+                                  crossAxisAlignment: CrossAxisAlignment.end,
+                                  children: <Widget>[
                                     Padding(
                                       padding: EdgeInsets.symmetric(
                                         horizontal: constraints.maxWidth * 0.02,
@@ -315,7 +219,7 @@ class _MessageListViewState extends State<MessageListView> {
                                             (widget.showAvatarForEverMessage ||
                                                         showAvatar) &&
                                                     widget.messages[i].user
-                                                            .uid ==
+                                                            .uid !=
                                                         widget.user.uid
                                                 ? 1
                                                 : 0,
@@ -327,38 +231,142 @@ class _MessageListViewState extends State<MessageListView> {
                                           avatarMaxSize: widget.avatarMaxSize,
                                         ),
                                       ),
-                                    )
-                                  else
-                                    SizedBox(
-                                      width: 10.0,
                                     ),
-                                ],
-                              ),
-                              if (showPreviousDate)
-                                DateBuilder(
-                                  date: previousDate,
-                                  customDateBuilder: widget.dateBuilder,
-                                  dateFormat: widget.dateFormat,
+                                    Expanded(
+                                      child: GestureDetector(
+                                        onLongPress: () {
+                                          if (widget.onLongPressMessage !=
+                                              null) {
+                                            widget.onLongPressMessage(
+                                                widget.messages[i]);
+                                          } else {
+                                            showBottomSheet(
+                                                context: context,
+                                                builder: (context) => Container(
+                                                      child: Column(
+                                                        mainAxisSize:
+                                                            MainAxisSize.min,
+                                                        children: <Widget>[
+                                                          ListTile(
+                                                            leading: Icon(Icons
+                                                                .content_copy),
+                                                            title: Text(
+                                                                "Copy to clipboard"),
+                                                            onTap: () {
+                                                              Clipboard.setData(
+                                                                  ClipboardData(
+                                                                      text: widget
+                                                                          .messages[
+                                                                              i]
+                                                                          .text));
+                                                              Navigator.pop(
+                                                                  context);
+                                                            },
+                                                          )
+                                                        ],
+                                                      ),
+                                                    ));
+                                          }
+                                        },
+                                        child: widget.messageBuilder != null
+                                            ? widget.messageBuilder(
+                                                widget.messages[i])
+                                            : Align(
+                                                alignment: widget.messages[i]
+                                                            .user.uid ==
+                                                        widget.user.uid
+                                                    ? AlignmentDirectional
+                                                        .centerEnd
+                                                    : AlignmentDirectional
+                                                        .centerStart,
+                                                child: MessageContainer(
+                                                  messagePadding:
+                                                      widget.messagePadding,
+                                                  constraints: constraints,
+                                                  isUser: widget.messages[i]
+                                                          .user.uid ==
+                                                      widget.user.uid,
+                                                  message: widget.messages[i],
+                                                  timeFormat: widget.timeFormat,
+                                                  messageImageBuilder: widget
+                                                      .messageImageBuilder,
+                                                  messageTextBuilder:
+                                                      widget.messageTextBuilder,
+                                                  messageTimeBuilder:
+                                                      widget.messageTimeBuilder,
+                                                  messageContainerDecoration: widget
+                                                      .messageContainerDecoration,
+                                                  parsePatterns:
+                                                      widget.parsePatterns,
+                                                  buttons: widget
+                                                      .messages[i].buttons,
+                                                  messageButtonsBuilder: widget
+                                                      .messageButtonsBuilder,
+                                                  textBeforeImage:
+                                                      widget.textBeforeImage,
+                                                  messageDecorationBuilder: widget
+                                                      .messageDecorationBuilder,
+                                                ),
+                                              ),
+                                      ),
+                                    ),
+                                    if (widget.showUserAvatar)
+                                      Padding(
+                                        padding: EdgeInsets.symmetric(
+                                          horizontal:
+                                              constraints.maxWidth * 0.02,
+                                        ),
+                                        child: Opacity(
+                                          opacity:
+                                              (widget.showAvatarForEverMessage ||
+                                                          showAvatar) &&
+                                                      widget.messages[i].user
+                                                              .uid ==
+                                                          widget.user.uid
+                                                  ? 1
+                                                  : 0,
+                                          child: AvatarContainer(
+                                            user: widget.messages[i].user,
+                                            onPress: widget.onPressAvatar,
+                                            onLongPress:
+                                                widget.onLongPressAvatar,
+                                            avatarBuilder: widget.avatarBuilder,
+                                            avatarMaxSize: widget.avatarMaxSize,
+                                          ),
+                                        ),
+                                      )
+                                    else
+                                      SizedBox(
+                                        width: 10.0,
+                                      ),
+                                  ],
                                 ),
-                            ],
-                          ),
-                        );
-                      },
-                    ),
-                    Container(
-                      height: 100.0,
-                    ),
-                    AnimatedPositioned(
-                      top: widget.showLoadMore ? 8.0 : -50.0,
-                      duration: Duration(milliseconds: 200),
-                      child: widget.showLoadEarlierWidget != null
-                          ? widget.showLoadEarlierWidget()
-                          : LoadEarlierWidget(
-                              onLoadEarlier: widget.onLoadEarlier,
-                              defaultLoadCallback: widget.defaultLoadCallback,
+                                if (showPreviousDate)
+                                  DateBuilder(
+                                    date: previousDate,
+                                    customDateBuilder: widget.dateBuilder,
+                                    dateFormat: widget.dateFormat,
+                                  ),
+                              ],
                             ),
-                    ),
-                  ],
+                          );
+                        },
+                      ),
+                      Container(
+                        height: 100.0,
+                      ),
+                      AnimatedPositioned(
+                        top: widget.showLoadMore ? 8.0 : -50.0,
+                        duration: Duration(milliseconds: 200),
+                        child: widget.showLoadEarlierWidget != null
+                            ? widget.showLoadEarlierWidget()
+                            : LoadEarlierWidget(
+                                onLoadEarlier: widget.onLoadEarlier,
+                                defaultLoadCallback: widget.defaultLoadCallback,
+                              ),
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -123,251 +123,271 @@ class _MessageListViewState extends State<MessageListView> {
             maxHeight: MediaQuery.of(context).size.height,
             maxWidth: MediaQuery.of(context).size.width);
     final itemCount = widget.messages.length;
-    return SliverFillRemaining(
-      child: Flexible(
-        child: GestureDetector(
-          onTap: () {
-            final currentFocus = FocusScope.of(context);
-            if (!currentFocus.hasPrimaryFocus && currentFocus.hasFocus) {
-              FocusManager.instance.primaryFocus.unfocus();
-            }
-          },
-          child: Padding(
-            padding: widget.messageContainerPadding,
-            child: NotificationListener<ScrollNotification>(
-              onNotification: scrollNotificationFunc,
-              child: Stack(
-                alignment: AlignmentDirectional.topCenter,
-                children: [
-                  Container(
-                    color: Colors.red,
-                    child: ListView.builder(
-                      controller: widget.scrollController,
-                      physics: widget.scrollPhysics,
-                      keyboardDismissBehavior:
-                          ScrollViewKeyboardDismissBehavior.onDrag,
-                      shrinkWrap: true,
-                      reverse: widget.inverted,
-                      itemCount: itemCount,
-                      itemBuilder: (context, i) {
-                        bool showAvatar = shouldShowAvatar(i);
-                        bool first = i == 0;
-                        bool last = i == itemCount - 1;
+    return Flexible(
+      child: GestureDetector(
+        onTap: () {
+          final currentFocus = FocusScope.of(context);
+          if (!currentFocus.hasPrimaryFocus && currentFocus.hasFocus) {
+            FocusManager.instance.primaryFocus.unfocus();
+          }
+        },
+        child: Padding(
+          padding: widget.messageContainerPadding,
+          child: NotificationListener<ScrollNotification>(
+            onNotification: scrollNotificationFunc,
+            child: Stack(
+              alignment: AlignmentDirectional.topCenter,
+              children: [
+                Container(
+                  color: Colors.red,
+                  child: IntrinsicHeight(
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        ListView.builder(
+                          controller: widget.scrollController,
+                          physics: widget.scrollPhysics,
+                          keyboardDismissBehavior:
+                              ScrollViewKeyboardDismissBehavior.onDrag,
+                          shrinkWrap: true,
+                          reverse: widget.inverted,
+                          itemCount: itemCount,
+                          itemBuilder: (context, i) {
+                            bool showAvatar = shouldShowAvatar(i);
+                            bool first = i == 0;
+                            bool last = i == itemCount - 1;
 
-                        DateTime currentDate = DateTime(
-                          widget.messages[i].createdAt.year,
-                          widget.messages[i].createdAt.month,
-                          widget.messages[i].createdAt.day,
-                        );
+                            DateTime currentDate = DateTime(
+                              widget.messages[i].createdAt.year,
+                              widget.messages[i].createdAt.month,
+                              widget.messages[i].createdAt.day,
+                            );
 
-                        DateTime previousDate;
-                        if (i == 0) {
-                          previousDate = currentDate;
-                        } else {
-                          previousDate = DateTime(
-                            widget.messages[i - 1].createdAt.year,
-                            widget.messages[i - 1].createdAt.month,
-                            widget.messages[i - 1].createdAt.day,
-                          );
-                        }
-                        bool showCurrentDate = false;
-                        bool showPreviousDate = false;
-                        if (currentDate.difference(previousDate).inDays != 0) {
-                          if (widget.inverted) {
-                            showPreviousDate = true;
-                            if (last) {
+                            DateTime previousDate;
+                            if (i == 0) {
+                              previousDate = currentDate;
+                            } else {
+                              previousDate = DateTime(
+                                widget.messages[i - 1].createdAt.year,
+                                widget.messages[i - 1].createdAt.month,
+                                widget.messages[i - 1].createdAt.day,
+                              );
+                            }
+                            bool showCurrentDate = false;
+                            bool showPreviousDate = false;
+                            if (currentDate.difference(previousDate).inDays !=
+                                0) {
+                              if (widget.inverted) {
+                                showPreviousDate = true;
+                                if (last) {
+                                  showCurrentDate = true;
+                                }
+                              } else {
+                                showCurrentDate = true;
+                                if (first) {
+                                  showPreviousDate = true;
+                                }
+                              }
+                            } else if (widget.inverted && last) {
+                              showCurrentDate = true;
+                            } else if (!widget.inverted && first) {
                               showCurrentDate = true;
                             }
-                          } else {
-                            showCurrentDate = true;
-                            if (first) {
-                              showPreviousDate = true;
-                            }
-                          }
-                        } else if (widget.inverted && last) {
-                          showCurrentDate = true;
-                        } else if (!widget.inverted && first) {
-                          showCurrentDate = true;
-                        }
 
-                        return Container(
-                          color: Colors.blue,
-                          child: Align(
-                            child: Column(
-                              children: <Widget>[
-                                if (showCurrentDate)
-                                  DateBuilder(
-                                    date: currentDate,
-                                    customDateBuilder: widget.dateBuilder,
-                                    dateFormat: widget.dateFormat,
-                                  ),
-                                Row(
-                                  mainAxisAlignment:
-                                      widget.messages[i].user.uid ==
-                                              widget.user.uid
-                                          ? MainAxisAlignment.end
-                                          : MainAxisAlignment.start,
-                                  crossAxisAlignment: CrossAxisAlignment.end,
+                            return Container(
+                              color: Colors.blue,
+                              child: Align(
+                                child: Column(
                                   children: <Widget>[
-                                    Padding(
-                                      padding: EdgeInsets.symmetric(
-                                        horizontal: constraints.maxWidth * 0.02,
+                                    if (showCurrentDate)
+                                      DateBuilder(
+                                        date: currentDate,
+                                        customDateBuilder: widget.dateBuilder,
+                                        dateFormat: widget.dateFormat,
                                       ),
-                                      child: Opacity(
-                                        opacity:
-                                            (widget.showAvatarForEverMessage ||
-                                                        showAvatar) &&
-                                                    widget.messages[i].user
-                                                            .uid !=
-                                                        widget.user.uid
-                                                ? 1
-                                                : 0,
-                                        child: AvatarContainer(
-                                          user: widget.messages[i].user,
-                                          onPress: widget.onPressAvatar,
-                                          onLongPress: widget.onLongPressAvatar,
-                                          avatarBuilder: widget.avatarBuilder,
-                                          avatarMaxSize: widget.avatarMaxSize,
+                                    Row(
+                                      mainAxisAlignment:
+                                          widget.messages[i].user.uid ==
+                                                  widget.user.uid
+                                              ? MainAxisAlignment.end
+                                              : MainAxisAlignment.start,
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.end,
+                                      children: <Widget>[
+                                        Padding(
+                                          padding: EdgeInsets.symmetric(
+                                            horizontal:
+                                                constraints.maxWidth * 0.02,
+                                          ),
+                                          child: Opacity(
+                                            opacity:
+                                                (widget.showAvatarForEverMessage ||
+                                                            showAvatar) &&
+                                                        widget.messages[i].user
+                                                                .uid !=
+                                                            widget.user.uid
+                                                    ? 1
+                                                    : 0,
+                                            child: AvatarContainer(
+                                              user: widget.messages[i].user,
+                                              onPress: widget.onPressAvatar,
+                                              onLongPress:
+                                                  widget.onLongPressAvatar,
+                                              avatarBuilder:
+                                                  widget.avatarBuilder,
+                                              avatarMaxSize:
+                                                  widget.avatarMaxSize,
+                                            ),
+                                          ),
                                         ),
-                                      ),
-                                    ),
-                                    Expanded(
-                                      child: GestureDetector(
-                                        onLongPress: () {
-                                          if (widget.onLongPressMessage !=
-                                              null) {
-                                            widget.onLongPressMessage(
-                                                widget.messages[i]);
-                                          } else {
-                                            showBottomSheet(
-                                                context: context,
-                                                builder: (context) => Container(
-                                                      child: Column(
-                                                        mainAxisSize:
-                                                            MainAxisSize.min,
-                                                        children: <Widget>[
-                                                          ListTile(
-                                                            leading: Icon(Icons
-                                                                .content_copy),
-                                                            title: Text(
-                                                                "Copy to clipboard"),
-                                                            onTap: () {
-                                                              Clipboard.setData(
-                                                                  ClipboardData(
+                                        Expanded(
+                                          child: GestureDetector(
+                                            onLongPress: () {
+                                              if (widget.onLongPressMessage !=
+                                                  null) {
+                                                widget.onLongPressMessage(
+                                                    widget.messages[i]);
+                                              } else {
+                                                showBottomSheet(
+                                                    context: context,
+                                                    builder: (context) =>
+                                                        Container(
+                                                          child: Column(
+                                                            mainAxisSize:
+                                                                MainAxisSize
+                                                                    .min,
+                                                            children: <Widget>[
+                                                              ListTile(
+                                                                leading: Icon(Icons
+                                                                    .content_copy),
+                                                                title: Text(
+                                                                    "Copy to clipboard"),
+                                                                onTap: () {
+                                                                  Clipboard.setData(ClipboardData(
                                                                       text: widget
                                                                           .messages[
                                                                               i]
                                                                           .text));
-                                                              Navigator.pop(
-                                                                  context);
-                                                            },
-                                                          )
-                                                        ],
-                                                      ),
-                                                    ));
-                                          }
-                                        },
-                                        child: widget.messageBuilder != null
-                                            ? widget.messageBuilder(
-                                                widget.messages[i])
-                                            : Align(
-                                                alignment: widget.messages[i]
-                                                            .user.uid ==
-                                                        widget.user.uid
-                                                    ? AlignmentDirectional
-                                                        .centerEnd
-                                                    : AlignmentDirectional
-                                                        .centerStart,
-                                                child: MessageContainer(
-                                                  messagePadding:
-                                                      widget.messagePadding,
-                                                  constraints: constraints,
-                                                  isUser: widget.messages[i]
-                                                          .user.uid ==
-                                                      widget.user.uid,
-                                                  message: widget.messages[i],
-                                                  timeFormat: widget.timeFormat,
-                                                  messageImageBuilder: widget
-                                                      .messageImageBuilder,
-                                                  messageTextBuilder:
-                                                      widget.messageTextBuilder,
-                                                  messageTimeBuilder:
-                                                      widget.messageTimeBuilder,
-                                                  messageContainerDecoration: widget
-                                                      .messageContainerDecoration,
-                                                  parsePatterns:
-                                                      widget.parsePatterns,
-                                                  buttons: widget
-                                                      .messages[i].buttons,
-                                                  messageButtonsBuilder: widget
-                                                      .messageButtonsBuilder,
-                                                  textBeforeImage:
-                                                      widget.textBeforeImage,
-                                                  messageDecorationBuilder: widget
-                                                      .messageDecorationBuilder,
-                                                ),
-                                              ),
-                                      ),
-                                    ),
-                                    if (widget.showUserAvatar)
-                                      Padding(
-                                        padding: EdgeInsets.symmetric(
-                                          horizontal:
-                                              constraints.maxWidth * 0.02,
-                                        ),
-                                        child: Opacity(
-                                          opacity:
-                                              (widget.showAvatarForEverMessage ||
-                                                          showAvatar) &&
-                                                      widget.messages[i].user
-                                                              .uid ==
-                                                          widget.user.uid
-                                                  ? 1
-                                                  : 0,
-                                          child: AvatarContainer(
-                                            user: widget.messages[i].user,
-                                            onPress: widget.onPressAvatar,
-                                            onLongPress:
-                                                widget.onLongPressAvatar,
-                                            avatarBuilder: widget.avatarBuilder,
-                                            avatarMaxSize: widget.avatarMaxSize,
+                                                                  Navigator.pop(
+                                                                      context);
+                                                                },
+                                                              )
+                                                            ],
+                                                          ),
+                                                        ));
+                                              }
+                                            },
+                                            child: widget.messageBuilder != null
+                                                ? widget.messageBuilder(
+                                                    widget.messages[i])
+                                                : Align(
+                                                    alignment: widget
+                                                                .messages[i]
+                                                                .user
+                                                                .uid ==
+                                                            widget.user.uid
+                                                        ? AlignmentDirectional
+                                                            .centerEnd
+                                                        : AlignmentDirectional
+                                                            .centerStart,
+                                                    child: MessageContainer(
+                                                      messagePadding:
+                                                          widget.messagePadding,
+                                                      constraints: constraints,
+                                                      isUser: widget.messages[i]
+                                                              .user.uid ==
+                                                          widget.user.uid,
+                                                      message:
+                                                          widget.messages[i],
+                                                      timeFormat:
+                                                          widget.timeFormat,
+                                                      messageImageBuilder: widget
+                                                          .messageImageBuilder,
+                                                      messageTextBuilder: widget
+                                                          .messageTextBuilder,
+                                                      messageTimeBuilder: widget
+                                                          .messageTimeBuilder,
+                                                      messageContainerDecoration:
+                                                          widget
+                                                              .messageContainerDecoration,
+                                                      parsePatterns:
+                                                          widget.parsePatterns,
+                                                      buttons: widget
+                                                          .messages[i].buttons,
+                                                      messageButtonsBuilder: widget
+                                                          .messageButtonsBuilder,
+                                                      textBeforeImage: widget
+                                                          .textBeforeImage,
+                                                      messageDecorationBuilder:
+                                                          widget
+                                                              .messageDecorationBuilder,
+                                                    ),
+                                                  ),
                                           ),
                                         ),
-                                      )
-                                    else
-                                      SizedBox(
-                                        width: 10.0,
+                                        if (widget.showUserAvatar)
+                                          Padding(
+                                            padding: EdgeInsets.symmetric(
+                                              horizontal:
+                                                  constraints.maxWidth * 0.02,
+                                            ),
+                                            child: Opacity(
+                                              opacity:
+                                                  (widget.showAvatarForEverMessage ||
+                                                              showAvatar) &&
+                                                          widget.messages[i]
+                                                                  .user.uid ==
+                                                              widget.user.uid
+                                                      ? 1
+                                                      : 0,
+                                              child: AvatarContainer(
+                                                user: widget.messages[i].user,
+                                                onPress: widget.onPressAvatar,
+                                                onLongPress:
+                                                    widget.onLongPressAvatar,
+                                                avatarBuilder:
+                                                    widget.avatarBuilder,
+                                                avatarMaxSize:
+                                                    widget.avatarMaxSize,
+                                              ),
+                                            ),
+                                          )
+                                        else
+                                          SizedBox(
+                                            width: 10.0,
+                                          ),
+                                      ],
+                                    ),
+                                    if (showPreviousDate)
+                                      DateBuilder(
+                                        date: previousDate,
+                                        customDateBuilder: widget.dateBuilder,
+                                        dateFormat: widget.dateFormat,
                                       ),
                                   ],
                                 ),
-                                if (showPreviousDate)
-                                  DateBuilder(
-                                    date: previousDate,
-                                    customDateBuilder: widget.dateBuilder,
-                                    dateFormat: widget.dateFormat,
-                                  ),
-                              ],
-                            ),
-                          ),
-                        );
-                      },
+                              ),
+                            );
+                          },
+                        ),
+                      ],
                     ),
                   ),
-                  Container(
-                    height: 100.0,
-                  ),
-                  AnimatedPositioned(
-                    top: widget.showLoadMore ? 8.0 : -50.0,
-                    duration: Duration(milliseconds: 200),
-                    child: widget.showLoadEarlierWidget != null
-                        ? widget.showLoadEarlierWidget()
-                        : LoadEarlierWidget(
-                            onLoadEarlier: widget.onLoadEarlier,
-                            defaultLoadCallback: widget.defaultLoadCallback,
-                          ),
-                  ),
-                ],
-              ),
+                ),
+                Container(
+                  height: 100.0,
+                ),
+                AnimatedPositioned(
+                  top: widget.showLoadMore ? 8.0 : -50.0,
+                  duration: Duration(milliseconds: 200),
+                  child: widget.showLoadEarlierWidget != null
+                      ? widget.showLoadEarlierWidget()
+                      : LoadEarlierWidget(
+                          onLoadEarlier: widget.onLoadEarlier,
+                          defaultLoadCallback: widget.defaultLoadCallback,
+                        ),
+                ),
+              ],
             ),
           ),
         ),

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -123,7 +123,7 @@ class _MessageListViewState extends State<MessageListView> {
             maxHeight: MediaQuery.of(context).size.height,
             maxWidth: MediaQuery.of(context).size.width);
     final itemCount = widget.messages.length;
-    return Flexible(
+    return Expanded(
       child: GestureDetector(
         onTap: () {
           final currentFocus = FocusScope.of(context);

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -12,7 +12,7 @@ class MessageListView extends StatefulWidget {
   final bool renderAvatarOnTop;
   final Function(ChatMessage) onLongPressMessage;
   final bool inverted;
-  final Widget topOfMessagesWidget;
+  final Widget Function() messageListHeaderBuilder;
   final Widget Function(ChatUser) avatarBuilder;
   final Widget Function(ChatMessage) messageBuilder;
   final Widget Function(String, [ChatMessage]) messageTextBuilder;
@@ -58,7 +58,7 @@ class MessageListView extends StatefulWidget {
     this.timeFormat,
     this.showAvatarForEverMessage,
     this.inverted,
-    this.topOfMessagesWidget,
+    this.messageListHeaderBuilder,
     this.onLongPressAvatar,
     this.onLongPressMessage,
     this.onPressAvatar,
@@ -140,8 +140,8 @@ class _MessageListViewState extends State<MessageListView> {
             child: Stack(
               alignment: AlignmentDirectional.topCenter,
               children: [
-                if (itemCount == 0 && widget.topOfMessagesWidget != null)
-                  widget.topOfMessagesWidget,
+                if (itemCount == 0 && widget.messageListHeaderBuilder != null)
+                  widget.messageListHeaderBuilder(),
                 ListView.builder(
                   controller: widget.scrollController,
                   physics: widget.scrollPhysics,
@@ -194,8 +194,8 @@ class _MessageListViewState extends State<MessageListView> {
                     return Align(
                       child: Column(
                         children: <Widget>[
-                          if (last && widget.topOfMessagesWidget != null)
-                            widget.topOfMessagesWidget,
+                          if (last && widget.messageListHeaderBuilder != null)
+                            widget.messageListHeaderBuilder(),
                           if (showCurrentDate)
                             DateBuilder(
                               date: currentDate,

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -190,17 +190,18 @@ class _MessageListViewState extends State<MessageListView> {
                     return Align(
                       child: Column(
                         children: <Widget>[
-                          Container(
-                            height: 100,
-                            width: constraints.maxWidth,
-                            color: Colors.indigo,
-                            child: Text(
-                              'Image goes here',
-                              style: TextStyle(
-                                color: Colors.white,
+                          if (itemCount == 0 || first)
+                            Container(
+                              height: 100,
+                              width: constraints.maxWidth,
+                              color: Colors.indigo,
+                              child: Text(
+                                'Image goes here',
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
                               ),
                             ),
-                          ),
                           if (showCurrentDate)
                             DateBuilder(
                               date: currentDate,

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -124,7 +124,6 @@ class _MessageListViewState extends State<MessageListView> {
             maxWidth: MediaQuery.of(context).size.width);
     final itemCount = widget.messages.length;
     return Flexible(
-      fit: FlexFit.tight,
       child: GestureDetector(
         onTap: () {
           final currentFocus = FocusScope.of(context);

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -123,75 +123,75 @@ class _MessageListViewState extends State<MessageListView> {
             maxHeight: MediaQuery.of(context).size.height,
             maxWidth: MediaQuery.of(context).size.width);
     final itemCount = widget.messages.length;
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.start,
-      children: [
-        GestureDetector(
-          onTap: () {
-            final currentFocus = FocusScope.of(context);
-            if (!currentFocus.hasPrimaryFocus && currentFocus.hasFocus) {
-              FocusManager.instance.primaryFocus.unfocus();
-            }
-          },
-          child: Padding(
-            padding: widget.messageContainerPadding,
-            child: NotificationListener<ScrollNotification>(
-              onNotification: scrollNotificationFunc,
-              child: Stack(
-                alignment: AlignmentDirectional.topCenter,
-                children: [
-                  Container(
-                    color: Colors.red,
-                    child: ListView.builder(
-                      controller: widget.scrollController,
-                      physics: widget.scrollPhysics,
-                      keyboardDismissBehavior:
-                          ScrollViewKeyboardDismissBehavior.onDrag,
-                      shrinkWrap: false,
-                      reverse: widget.inverted,
-                      itemCount: itemCount,
-                      itemBuilder: (context, i) {
-                        bool showAvatar = shouldShowAvatar(i);
-                        bool first = i == 0;
-                        bool last = i == itemCount - 1;
+    return Flexible(
+      child: GestureDetector(
+        onTap: () {
+          final currentFocus = FocusScope.of(context);
+          if (!currentFocus.hasPrimaryFocus && currentFocus.hasFocus) {
+            FocusManager.instance.primaryFocus.unfocus();
+          }
+        },
+        child: Padding(
+          padding: widget.messageContainerPadding,
+          child: NotificationListener<ScrollNotification>(
+            onNotification: scrollNotificationFunc,
+            child: Stack(
+              alignment: AlignmentDirectional.topCenter,
+              children: [
+                Container(
+                  color: Colors.red,
+                  child: ListView.builder(
+                    controller: widget.scrollController,
+                    physics: widget.scrollPhysics,
+                    keyboardDismissBehavior:
+                        ScrollViewKeyboardDismissBehavior.onDrag,
+                    shrinkWrap: false,
+                    reverse: widget.inverted,
+                    itemCount: itemCount,
+                    itemBuilder: (context, i) {
+                      bool showAvatar = shouldShowAvatar(i);
+                      bool first = i == 0;
+                      bool last = i == itemCount - 1;
 
-                        DateTime currentDate = DateTime(
-                          widget.messages[i].createdAt.year,
-                          widget.messages[i].createdAt.month,
-                          widget.messages[i].createdAt.day,
+                      DateTime currentDate = DateTime(
+                        widget.messages[i].createdAt.year,
+                        widget.messages[i].createdAt.month,
+                        widget.messages[i].createdAt.day,
+                      );
+
+                      DateTime previousDate;
+                      if (i == 0) {
+                        previousDate = currentDate;
+                      } else {
+                        previousDate = DateTime(
+                          widget.messages[i - 1].createdAt.year,
+                          widget.messages[i - 1].createdAt.month,
+                          widget.messages[i - 1].createdAt.day,
                         );
-
-                        DateTime previousDate;
-                        if (i == 0) {
-                          previousDate = currentDate;
-                        } else {
-                          previousDate = DateTime(
-                            widget.messages[i - 1].createdAt.year,
-                            widget.messages[i - 1].createdAt.month,
-                            widget.messages[i - 1].createdAt.day,
-                          );
-                        }
-                        bool showCurrentDate = false;
-                        bool showPreviousDate = false;
-                        if (currentDate.difference(previousDate).inDays != 0) {
-                          if (widget.inverted) {
-                            showPreviousDate = true;
-                            if (last) {
-                              showCurrentDate = true;
-                            }
-                          } else {
+                      }
+                      bool showCurrentDate = false;
+                      bool showPreviousDate = false;
+                      if (currentDate.difference(previousDate).inDays != 0) {
+                        if (widget.inverted) {
+                          showPreviousDate = true;
+                          if (last) {
                             showCurrentDate = true;
-                            if (first) {
-                              showPreviousDate = true;
-                            }
                           }
-                        } else if (widget.inverted && last) {
+                        } else {
                           showCurrentDate = true;
-                        } else if (!widget.inverted && first) {
-                          showCurrentDate = true;
+                          if (first) {
+                            showPreviousDate = true;
+                          }
                         }
+                      } else if (widget.inverted && last) {
+                        showCurrentDate = true;
+                      } else if (!widget.inverted && first) {
+                        showCurrentDate = true;
+                      }
 
-                        return Align(
+                      return Container(
+                        color: Colors.blue,
+                        child: Align(
                           child: Column(
                             children: <Widget>[
                               if (showCurrentDate)
@@ -343,29 +343,29 @@ class _MessageListViewState extends State<MessageListView> {
                                 ),
                             ],
                           ),
-                        );
-                      },
-                    ),
+                        ),
+                      );
+                    },
                   ),
-                  Container(
-                    height: 100.0,
-                  ),
-                  AnimatedPositioned(
-                    top: widget.showLoadMore ? 8.0 : -50.0,
-                    duration: Duration(milliseconds: 200),
-                    child: widget.showLoadEarlierWidget != null
-                        ? widget.showLoadEarlierWidget()
-                        : LoadEarlierWidget(
-                            onLoadEarlier: widget.onLoadEarlier,
-                            defaultLoadCallback: widget.defaultLoadCallback,
-                          ),
-                  ),
-                ],
-              ),
+                ),
+                Container(
+                  height: 100.0,
+                ),
+                AnimatedPositioned(
+                  top: widget.showLoadMore ? 8.0 : -50.0,
+                  duration: Duration(milliseconds: 200),
+                  child: widget.showLoadEarlierWidget != null
+                      ? widget.showLoadEarlierWidget()
+                      : LoadEarlierWidget(
+                          onLoadEarlier: widget.onLoadEarlier,
+                          defaultLoadCallback: widget.defaultLoadCallback,
+                        ),
+                ),
+              ],
             ),
           ),
         ),
-      ],
+      ),
     );
   }
 }

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -124,7 +124,7 @@ class _MessageListViewState extends State<MessageListView> {
             maxWidth: MediaQuery.of(context).size.width);
     final itemCount = widget.messages.length;
     return Flexible(
-      flex: 4,
+      fit: FlexFit.tight,
       child: GestureDetector(
         onTap: () {
           final currentFocus = FocusScope.of(context);

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -123,190 +123,92 @@ class _MessageListViewState extends State<MessageListView> {
             maxHeight: MediaQuery.of(context).size.height,
             maxWidth: MediaQuery.of(context).size.width);
     final itemCount = widget.messages.length;
-    return Expanded(
-      child: GestureDetector(
-        onTap: () {
-          final currentFocus = FocusScope.of(context);
-          if (!currentFocus.hasPrimaryFocus && currentFocus.hasFocus) {
-            FocusManager.instance.primaryFocus.unfocus();
-          }
-        },
-        child: Padding(
-          padding: widget.messageContainerPadding,
-          child: NotificationListener<ScrollNotification>(
-            onNotification: scrollNotificationFunc,
-            child: Stack(
-              alignment: AlignmentDirectional.topCenter,
-              children: [
-                Container(
-                  color: Colors.red,
-                  child: ListView.builder(
-                    controller: widget.scrollController,
-                    physics: widget.scrollPhysics,
-                    keyboardDismissBehavior:
-                        ScrollViewKeyboardDismissBehavior.onDrag,
-                    shrinkWrap: true,
-                    reverse: widget.inverted,
-                    itemCount: itemCount,
-                    itemBuilder: (context, i) {
-                      bool showAvatar = shouldShowAvatar(i);
-                      bool first = i == 0;
-                      bool last = i == itemCount - 1;
+    return SliverFillRemaining(
+      child: Flexible(
+        child: GestureDetector(
+          onTap: () {
+            final currentFocus = FocusScope.of(context);
+            if (!currentFocus.hasPrimaryFocus && currentFocus.hasFocus) {
+              FocusManager.instance.primaryFocus.unfocus();
+            }
+          },
+          child: Padding(
+            padding: widget.messageContainerPadding,
+            child: NotificationListener<ScrollNotification>(
+              onNotification: scrollNotificationFunc,
+              child: Stack(
+                alignment: AlignmentDirectional.topCenter,
+                children: [
+                  Container(
+                    color: Colors.red,
+                    child: ListView.builder(
+                      controller: widget.scrollController,
+                      physics: widget.scrollPhysics,
+                      keyboardDismissBehavior:
+                          ScrollViewKeyboardDismissBehavior.onDrag,
+                      shrinkWrap: true,
+                      reverse: widget.inverted,
+                      itemCount: itemCount,
+                      itemBuilder: (context, i) {
+                        bool showAvatar = shouldShowAvatar(i);
+                        bool first = i == 0;
+                        bool last = i == itemCount - 1;
 
-                      DateTime currentDate = DateTime(
-                        widget.messages[i].createdAt.year,
-                        widget.messages[i].createdAt.month,
-                        widget.messages[i].createdAt.day,
-                      );
-
-                      DateTime previousDate;
-                      if (i == 0) {
-                        previousDate = currentDate;
-                      } else {
-                        previousDate = DateTime(
-                          widget.messages[i - 1].createdAt.year,
-                          widget.messages[i - 1].createdAt.month,
-                          widget.messages[i - 1].createdAt.day,
+                        DateTime currentDate = DateTime(
+                          widget.messages[i].createdAt.year,
+                          widget.messages[i].createdAt.month,
+                          widget.messages[i].createdAt.day,
                         );
-                      }
-                      bool showCurrentDate = false;
-                      bool showPreviousDate = false;
-                      if (currentDate.difference(previousDate).inDays != 0) {
-                        if (widget.inverted) {
-                          showPreviousDate = true;
-                          if (last) {
-                            showCurrentDate = true;
-                          }
-                        } else {
-                          showCurrentDate = true;
-                          if (first) {
-                            showPreviousDate = true;
-                          }
-                        }
-                      } else if (widget.inverted && last) {
-                        showCurrentDate = true;
-                      } else if (!widget.inverted && first) {
-                        showCurrentDate = true;
-                      }
 
-                      return Container(
-                        color: Colors.blue,
-                        child: Align(
-                          child: Column(
-                            children: <Widget>[
-                              if (showCurrentDate)
-                                DateBuilder(
-                                  date: currentDate,
-                                  customDateBuilder: widget.dateBuilder,
-                                  dateFormat: widget.dateFormat,
-                                ),
-                              Row(
-                                mainAxisAlignment:
-                                    widget.messages[i].user.uid ==
-                                            widget.user.uid
-                                        ? MainAxisAlignment.end
-                                        : MainAxisAlignment.start,
-                                crossAxisAlignment: CrossAxisAlignment.end,
-                                children: <Widget>[
-                                  Padding(
-                                    padding: EdgeInsets.symmetric(
-                                      horizontal: constraints.maxWidth * 0.02,
-                                    ),
-                                    child: Opacity(
-                                      opacity:
-                                          (widget.showAvatarForEverMessage ||
-                                                      showAvatar) &&
-                                                  widget.messages[i].user.uid !=
-                                                      widget.user.uid
-                                              ? 1
-                                              : 0,
-                                      child: AvatarContainer(
-                                        user: widget.messages[i].user,
-                                        onPress: widget.onPressAvatar,
-                                        onLongPress: widget.onLongPressAvatar,
-                                        avatarBuilder: widget.avatarBuilder,
-                                        avatarMaxSize: widget.avatarMaxSize,
-                                      ),
-                                    ),
+                        DateTime previousDate;
+                        if (i == 0) {
+                          previousDate = currentDate;
+                        } else {
+                          previousDate = DateTime(
+                            widget.messages[i - 1].createdAt.year,
+                            widget.messages[i - 1].createdAt.month,
+                            widget.messages[i - 1].createdAt.day,
+                          );
+                        }
+                        bool showCurrentDate = false;
+                        bool showPreviousDate = false;
+                        if (currentDate.difference(previousDate).inDays != 0) {
+                          if (widget.inverted) {
+                            showPreviousDate = true;
+                            if (last) {
+                              showCurrentDate = true;
+                            }
+                          } else {
+                            showCurrentDate = true;
+                            if (first) {
+                              showPreviousDate = true;
+                            }
+                          }
+                        } else if (widget.inverted && last) {
+                          showCurrentDate = true;
+                        } else if (!widget.inverted && first) {
+                          showCurrentDate = true;
+                        }
+
+                        return Container(
+                          color: Colors.blue,
+                          child: Align(
+                            child: Column(
+                              children: <Widget>[
+                                if (showCurrentDate)
+                                  DateBuilder(
+                                    date: currentDate,
+                                    customDateBuilder: widget.dateBuilder,
+                                    dateFormat: widget.dateFormat,
                                   ),
-                                  Expanded(
-                                    child: GestureDetector(
-                                      onLongPress: () {
-                                        if (widget.onLongPressMessage != null) {
-                                          widget.onLongPressMessage(
-                                              widget.messages[i]);
-                                        } else {
-                                          showBottomSheet(
-                                              context: context,
-                                              builder: (context) => Container(
-                                                    child: Column(
-                                                      mainAxisSize:
-                                                          MainAxisSize.min,
-                                                      children: <Widget>[
-                                                        ListTile(
-                                                          leading: Icon(Icons
-                                                              .content_copy),
-                                                          title: Text(
-                                                              "Copy to clipboard"),
-                                                          onTap: () {
-                                                            Clipboard.setData(
-                                                                ClipboardData(
-                                                                    text: widget
-                                                                        .messages[
-                                                                            i]
-                                                                        .text));
-                                                            Navigator.pop(
-                                                                context);
-                                                          },
-                                                        )
-                                                      ],
-                                                    ),
-                                                  ));
-                                        }
-                                      },
-                                      child: widget.messageBuilder != null
-                                          ? widget.messageBuilder(
-                                              widget.messages[i])
-                                          : Align(
-                                              alignment:
-                                                  widget.messages[i].user.uid ==
-                                                          widget.user.uid
-                                                      ? AlignmentDirectional
-                                                          .centerEnd
-                                                      : AlignmentDirectional
-                                                          .centerStart,
-                                              child: MessageContainer(
-                                                messagePadding:
-                                                    widget.messagePadding,
-                                                constraints: constraints,
-                                                isUser: widget
-                                                        .messages[i].user.uid ==
-                                                    widget.user.uid,
-                                                message: widget.messages[i],
-                                                timeFormat: widget.timeFormat,
-                                                messageImageBuilder:
-                                                    widget.messageImageBuilder,
-                                                messageTextBuilder:
-                                                    widget.messageTextBuilder,
-                                                messageTimeBuilder:
-                                                    widget.messageTimeBuilder,
-                                                messageContainerDecoration: widget
-                                                    .messageContainerDecoration,
-                                                parsePatterns:
-                                                    widget.parsePatterns,
-                                                buttons:
-                                                    widget.messages[i].buttons,
-                                                messageButtonsBuilder: widget
-                                                    .messageButtonsBuilder,
-                                                textBeforeImage:
-                                                    widget.textBeforeImage,
-                                                messageDecorationBuilder: widget
-                                                    .messageDecorationBuilder,
-                                              ),
-                                            ),
-                                    ),
-                                  ),
-                                  if (widget.showUserAvatar)
+                                Row(
+                                  mainAxisAlignment:
+                                      widget.messages[i].user.uid ==
+                                              widget.user.uid
+                                          ? MainAxisAlignment.end
+                                          : MainAxisAlignment.start,
+                                  crossAxisAlignment: CrossAxisAlignment.end,
+                                  children: <Widget>[
                                     Padding(
                                       padding: EdgeInsets.symmetric(
                                         horizontal: constraints.maxWidth * 0.02,
@@ -316,7 +218,7 @@ class _MessageListViewState extends State<MessageListView> {
                                             (widget.showAvatarForEverMessage ||
                                                         showAvatar) &&
                                                     widget.messages[i].user
-                                                            .uid ==
+                                                            .uid !=
                                                         widget.user.uid
                                                 ? 1
                                                 : 0,
@@ -328,40 +230,144 @@ class _MessageListViewState extends State<MessageListView> {
                                           avatarMaxSize: widget.avatarMaxSize,
                                         ),
                                       ),
-                                    )
-                                  else
-                                    SizedBox(
-                                      width: 10.0,
                                     ),
-                                ],
-                              ),
-                              if (showPreviousDate)
-                                DateBuilder(
-                                  date: previousDate,
-                                  customDateBuilder: widget.dateBuilder,
-                                  dateFormat: widget.dateFormat,
+                                    Expanded(
+                                      child: GestureDetector(
+                                        onLongPress: () {
+                                          if (widget.onLongPressMessage !=
+                                              null) {
+                                            widget.onLongPressMessage(
+                                                widget.messages[i]);
+                                          } else {
+                                            showBottomSheet(
+                                                context: context,
+                                                builder: (context) => Container(
+                                                      child: Column(
+                                                        mainAxisSize:
+                                                            MainAxisSize.min,
+                                                        children: <Widget>[
+                                                          ListTile(
+                                                            leading: Icon(Icons
+                                                                .content_copy),
+                                                            title: Text(
+                                                                "Copy to clipboard"),
+                                                            onTap: () {
+                                                              Clipboard.setData(
+                                                                  ClipboardData(
+                                                                      text: widget
+                                                                          .messages[
+                                                                              i]
+                                                                          .text));
+                                                              Navigator.pop(
+                                                                  context);
+                                                            },
+                                                          )
+                                                        ],
+                                                      ),
+                                                    ));
+                                          }
+                                        },
+                                        child: widget.messageBuilder != null
+                                            ? widget.messageBuilder(
+                                                widget.messages[i])
+                                            : Align(
+                                                alignment: widget.messages[i]
+                                                            .user.uid ==
+                                                        widget.user.uid
+                                                    ? AlignmentDirectional
+                                                        .centerEnd
+                                                    : AlignmentDirectional
+                                                        .centerStart,
+                                                child: MessageContainer(
+                                                  messagePadding:
+                                                      widget.messagePadding,
+                                                  constraints: constraints,
+                                                  isUser: widget.messages[i]
+                                                          .user.uid ==
+                                                      widget.user.uid,
+                                                  message: widget.messages[i],
+                                                  timeFormat: widget.timeFormat,
+                                                  messageImageBuilder: widget
+                                                      .messageImageBuilder,
+                                                  messageTextBuilder:
+                                                      widget.messageTextBuilder,
+                                                  messageTimeBuilder:
+                                                      widget.messageTimeBuilder,
+                                                  messageContainerDecoration: widget
+                                                      .messageContainerDecoration,
+                                                  parsePatterns:
+                                                      widget.parsePatterns,
+                                                  buttons: widget
+                                                      .messages[i].buttons,
+                                                  messageButtonsBuilder: widget
+                                                      .messageButtonsBuilder,
+                                                  textBeforeImage:
+                                                      widget.textBeforeImage,
+                                                  messageDecorationBuilder: widget
+                                                      .messageDecorationBuilder,
+                                                ),
+                                              ),
+                                      ),
+                                    ),
+                                    if (widget.showUserAvatar)
+                                      Padding(
+                                        padding: EdgeInsets.symmetric(
+                                          horizontal:
+                                              constraints.maxWidth * 0.02,
+                                        ),
+                                        child: Opacity(
+                                          opacity:
+                                              (widget.showAvatarForEverMessage ||
+                                                          showAvatar) &&
+                                                      widget.messages[i].user
+                                                              .uid ==
+                                                          widget.user.uid
+                                                  ? 1
+                                                  : 0,
+                                          child: AvatarContainer(
+                                            user: widget.messages[i].user,
+                                            onPress: widget.onPressAvatar,
+                                            onLongPress:
+                                                widget.onLongPressAvatar,
+                                            avatarBuilder: widget.avatarBuilder,
+                                            avatarMaxSize: widget.avatarMaxSize,
+                                          ),
+                                        ),
+                                      )
+                                    else
+                                      SizedBox(
+                                        width: 10.0,
+                                      ),
+                                  ],
                                 ),
-                            ],
+                                if (showPreviousDate)
+                                  DateBuilder(
+                                    date: previousDate,
+                                    customDateBuilder: widget.dateBuilder,
+                                    dateFormat: widget.dateFormat,
+                                  ),
+                              ],
+                            ),
                           ),
-                        ),
-                      );
-                    },
+                        );
+                      },
+                    ),
                   ),
-                ),
-                Container(
-                  height: 100.0,
-                ),
-                AnimatedPositioned(
-                  top: widget.showLoadMore ? 8.0 : -50.0,
-                  duration: Duration(milliseconds: 200),
-                  child: widget.showLoadEarlierWidget != null
-                      ? widget.showLoadEarlierWidget()
-                      : LoadEarlierWidget(
-                          onLoadEarlier: widget.onLoadEarlier,
-                          defaultLoadCallback: widget.defaultLoadCallback,
-                        ),
-                ),
-              ],
+                  Container(
+                    height: 100.0,
+                  ),
+                  AnimatedPositioned(
+                    top: widget.showLoadMore ? 8.0 : -50.0,
+                    duration: Duration(milliseconds: 200),
+                    child: widget.showLoadEarlierWidget != null
+                        ? widget.showLoadEarlierWidget()
+                        : LoadEarlierWidget(
+                            onLoadEarlier: widget.onLoadEarlier,
+                            defaultLoadCallback: widget.defaultLoadCallback,
+                          ),
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -124,231 +124,252 @@ class _MessageListViewState extends State<MessageListView> {
             maxWidth: MediaQuery.of(context).size.width);
     final itemCount = widget.messages.length;
     return Flexible(
-      child: GestureDetector(
-        onTap: () {
-          final currentFocus = FocusScope.of(context);
-          if (!currentFocus.hasPrimaryFocus && currentFocus.hasFocus) {
-            FocusManager.instance.primaryFocus.unfocus();
-          }
-        },
-        child: Padding(
-          padding: widget.messageContainerPadding,
-          child: NotificationListener<ScrollNotification>(
-            onNotification: scrollNotificationFunc,
-            child: Stack(
-              alignment: AlignmentDirectional.topCenter,
-              children: [
-                ListView.builder(
-                  controller: widget.scrollController,
-                  physics: widget.scrollPhysics,
-                  keyboardDismissBehavior:
-                      ScrollViewKeyboardDismissBehavior.onDrag,
-                  shrinkWrap: true,
-                  reverse: widget.inverted,
-                  itemCount: itemCount,
-                  itemBuilder: (context, i) {
-                    bool showAvatar = shouldShowAvatar(i);
-                    bool first = i == 0;
-                    bool last = i == itemCount - 1;
+      child: IntrinsicHeight(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            GestureDetector(
+              onTap: () {
+                final currentFocus = FocusScope.of(context);
+                if (!currentFocus.hasPrimaryFocus && currentFocus.hasFocus) {
+                  FocusManager.instance.primaryFocus.unfocus();
+                }
+              },
+              child: Padding(
+                padding: widget.messageContainerPadding,
+                child: NotificationListener<ScrollNotification>(
+                  onNotification: scrollNotificationFunc,
+                  child: Stack(
+                    alignment: AlignmentDirectional.topCenter,
+                    children: [
+                      ListView.builder(
+                        controller: widget.scrollController,
+                        physics: widget.scrollPhysics,
+                        keyboardDismissBehavior:
+                            ScrollViewKeyboardDismissBehavior.onDrag,
+                        shrinkWrap: true,
+                        reverse: widget.inverted,
+                        itemCount: itemCount,
+                        itemBuilder: (context, i) {
+                          bool showAvatar = shouldShowAvatar(i);
+                          bool first = i == 0;
+                          bool last = i == itemCount - 1;
 
-                    DateTime currentDate = DateTime(
-                      widget.messages[i].createdAt.year,
-                      widget.messages[i].createdAt.month,
-                      widget.messages[i].createdAt.day,
-                    );
+                          DateTime currentDate = DateTime(
+                            widget.messages[i].createdAt.year,
+                            widget.messages[i].createdAt.month,
+                            widget.messages[i].createdAt.day,
+                          );
 
-                    DateTime previousDate;
-                    if (i == 0) {
-                      previousDate = currentDate;
-                    } else {
-                      previousDate = DateTime(
-                        widget.messages[i - 1].createdAt.year,
-                        widget.messages[i - 1].createdAt.month,
-                        widget.messages[i - 1].createdAt.day,
-                      );
-                    }
-                    bool showCurrentDate = false;
-                    bool showPreviousDate = false;
-                    if (currentDate.difference(previousDate).inDays != 0) {
-                      if (widget.inverted) {
-                        showPreviousDate = true;
-                        if (last) {
-                          showCurrentDate = true;
-                        }
-                      } else {
-                        showCurrentDate = true;
-                        if (first) {
-                          showPreviousDate = true;
-                        }
-                      }
-                    } else if (widget.inverted && last) {
-                      showCurrentDate = true;
-                    } else if (!widget.inverted && first) {
-                      showCurrentDate = true;
-                    }
+                          DateTime previousDate;
+                          if (i == 0) {
+                            previousDate = currentDate;
+                          } else {
+                            previousDate = DateTime(
+                              widget.messages[i - 1].createdAt.year,
+                              widget.messages[i - 1].createdAt.month,
+                              widget.messages[i - 1].createdAt.day,
+                            );
+                          }
+                          bool showCurrentDate = false;
+                          bool showPreviousDate = false;
+                          if (currentDate.difference(previousDate).inDays !=
+                              0) {
+                            if (widget.inverted) {
+                              showPreviousDate = true;
+                              if (last) {
+                                showCurrentDate = true;
+                              }
+                            } else {
+                              showCurrentDate = true;
+                              if (first) {
+                                showPreviousDate = true;
+                              }
+                            }
+                          } else if (widget.inverted && last) {
+                            showCurrentDate = true;
+                          } else if (!widget.inverted && first) {
+                            showCurrentDate = true;
+                          }
 
-                    return Align(
-                      child: Column(
-                        children: <Widget>[
-                          if (showCurrentDate)
-                            DateBuilder(
-                              date: currentDate,
-                              customDateBuilder: widget.dateBuilder,
-                              dateFormat: widget.dateFormat,
-                            ),
-                          Row(
-                            mainAxisAlignment:
-                                widget.messages[i].user.uid == widget.user.uid
-                                    ? MainAxisAlignment.end
-                                    : MainAxisAlignment.start,
-                            crossAxisAlignment: CrossAxisAlignment.end,
-                            children: <Widget>[
-                              Padding(
-                                padding: EdgeInsets.symmetric(
-                                  horizontal: constraints.maxWidth * 0.02,
-                                ),
-                                child: Opacity(
-                                  opacity: (widget.showAvatarForEverMessage ||
-                                              showAvatar) &&
-                                          widget.messages[i].user.uid !=
-                                              widget.user.uid
-                                      ? 1
-                                      : 0,
-                                  child: AvatarContainer(
-                                    user: widget.messages[i].user,
-                                    onPress: widget.onPressAvatar,
-                                    onLongPress: widget.onLongPressAvatar,
-                                    avatarBuilder: widget.avatarBuilder,
-                                    avatarMaxSize: widget.avatarMaxSize,
+                          return Align(
+                            child: Column(
+                              children: <Widget>[
+                                if (showCurrentDate)
+                                  DateBuilder(
+                                    date: currentDate,
+                                    customDateBuilder: widget.dateBuilder,
+                                    dateFormat: widget.dateFormat,
                                   ),
-                                ),
-                              ),
-                              Expanded(
-                                child: GestureDetector(
-                                  onLongPress: () {
-                                    if (widget.onLongPressMessage != null) {
-                                      widget.onLongPressMessage(
-                                          widget.messages[i]);
-                                    } else {
-                                      showBottomSheet(
-                                          context: context,
-                                          builder: (context) => Container(
-                                                child: Column(
-                                                  mainAxisSize:
-                                                      MainAxisSize.min,
-                                                  children: <Widget>[
-                                                    ListTile(
-                                                      leading: Icon(
-                                                          Icons.content_copy),
-                                                      title: Text(
-                                                          "Copy to clipboard"),
-                                                      onTap: () {
-                                                        Clipboard.setData(
-                                                            ClipboardData(
-                                                                text: widget
-                                                                    .messages[i]
-                                                                    .text));
-                                                        Navigator.pop(context);
-                                                      },
-                                                    )
-                                                  ],
+                                Row(
+                                  mainAxisAlignment:
+                                      widget.messages[i].user.uid ==
+                                              widget.user.uid
+                                          ? MainAxisAlignment.end
+                                          : MainAxisAlignment.start,
+                                  crossAxisAlignment: CrossAxisAlignment.end,
+                                  children: <Widget>[
+                                    Padding(
+                                      padding: EdgeInsets.symmetric(
+                                        horizontal: constraints.maxWidth * 0.02,
+                                      ),
+                                      child: Opacity(
+                                        opacity:
+                                            (widget.showAvatarForEverMessage ||
+                                                        showAvatar) &&
+                                                    widget.messages[i].user
+                                                            .uid !=
+                                                        widget.user.uid
+                                                ? 1
+                                                : 0,
+                                        child: AvatarContainer(
+                                          user: widget.messages[i].user,
+                                          onPress: widget.onPressAvatar,
+                                          onLongPress: widget.onLongPressAvatar,
+                                          avatarBuilder: widget.avatarBuilder,
+                                          avatarMaxSize: widget.avatarMaxSize,
+                                        ),
+                                      ),
+                                    ),
+                                    Expanded(
+                                      child: GestureDetector(
+                                        onLongPress: () {
+                                          if (widget.onLongPressMessage !=
+                                              null) {
+                                            widget.onLongPressMessage(
+                                                widget.messages[i]);
+                                          } else {
+                                            showBottomSheet(
+                                                context: context,
+                                                builder: (context) => Container(
+                                                      child: Column(
+                                                        mainAxisSize:
+                                                            MainAxisSize.min,
+                                                        children: <Widget>[
+                                                          ListTile(
+                                                            leading: Icon(Icons
+                                                                .content_copy),
+                                                            title: Text(
+                                                                "Copy to clipboard"),
+                                                            onTap: () {
+                                                              Clipboard.setData(
+                                                                  ClipboardData(
+                                                                      text: widget
+                                                                          .messages[
+                                                                              i]
+                                                                          .text));
+                                                              Navigator.pop(
+                                                                  context);
+                                                            },
+                                                          )
+                                                        ],
+                                                      ),
+                                                    ));
+                                          }
+                                        },
+                                        child: widget.messageBuilder != null
+                                            ? widget.messageBuilder(
+                                                widget.messages[i])
+                                            : Align(
+                                                alignment: widget.messages[i]
+                                                            .user.uid ==
+                                                        widget.user.uid
+                                                    ? AlignmentDirectional
+                                                        .centerEnd
+                                                    : AlignmentDirectional
+                                                        .centerStart,
+                                                child: MessageContainer(
+                                                  messagePadding:
+                                                      widget.messagePadding,
+                                                  constraints: constraints,
+                                                  isUser: widget.messages[i]
+                                                          .user.uid ==
+                                                      widget.user.uid,
+                                                  message: widget.messages[i],
+                                                  timeFormat: widget.timeFormat,
+                                                  messageImageBuilder: widget
+                                                      .messageImageBuilder,
+                                                  messageTextBuilder:
+                                                      widget.messageTextBuilder,
+                                                  messageTimeBuilder:
+                                                      widget.messageTimeBuilder,
+                                                  messageContainerDecoration: widget
+                                                      .messageContainerDecoration,
+                                                  parsePatterns:
+                                                      widget.parsePatterns,
+                                                  buttons: widget
+                                                      .messages[i].buttons,
+                                                  messageButtonsBuilder: widget
+                                                      .messageButtonsBuilder,
+                                                  textBeforeImage:
+                                                      widget.textBeforeImage,
+                                                  messageDecorationBuilder: widget
+                                                      .messageDecorationBuilder,
                                                 ),
-                                              ));
-                                    }
-                                  },
-                                  child: widget.messageBuilder != null
-                                      ? widget
-                                          .messageBuilder(widget.messages[i])
-                                      : Align(
-                                          alignment: widget
-                                                      .messages[i].user.uid ==
-                                                  widget.user.uid
-                                              ? AlignmentDirectional.centerEnd
-                                              : AlignmentDirectional
-                                                  .centerStart,
-                                          child: MessageContainer(
-                                            messagePadding:
-                                                widget.messagePadding,
-                                            constraints: constraints,
-                                            isUser:
-                                                widget.messages[i].user.uid ==
-                                                    widget.user.uid,
-                                            message: widget.messages[i],
-                                            timeFormat: widget.timeFormat,
-                                            messageImageBuilder:
-                                                widget.messageImageBuilder,
-                                            messageTextBuilder:
-                                                widget.messageTextBuilder,
-                                            messageTimeBuilder:
-                                                widget.messageTimeBuilder,
-                                            messageContainerDecoration: widget
-                                                .messageContainerDecoration,
-                                            parsePatterns: widget.parsePatterns,
-                                            buttons: widget.messages[i].buttons,
-                                            messageButtonsBuilder:
-                                                widget.messageButtonsBuilder,
-                                            textBeforeImage:
-                                                widget.textBeforeImage,
-                                            messageDecorationBuilder:
-                                                widget.messageDecorationBuilder,
+                                              ),
+                                      ),
+                                    ),
+                                    if (widget.showUserAvatar)
+                                      Padding(
+                                        padding: EdgeInsets.symmetric(
+                                          horizontal:
+                                              constraints.maxWidth * 0.02,
+                                        ),
+                                        child: Opacity(
+                                          opacity:
+                                              (widget.showAvatarForEverMessage ||
+                                                          showAvatar) &&
+                                                      widget.messages[i].user
+                                                              .uid ==
+                                                          widget.user.uid
+                                                  ? 1
+                                                  : 0,
+                                          child: AvatarContainer(
+                                            user: widget.messages[i].user,
+                                            onPress: widget.onPressAvatar,
+                                            onLongPress:
+                                                widget.onLongPressAvatar,
+                                            avatarBuilder: widget.avatarBuilder,
+                                            avatarMaxSize: widget.avatarMaxSize,
                                           ),
                                         ),
+                                      )
+                                    else
+                                      SizedBox(
+                                        width: 10.0,
+                                      ),
+                                  ],
                                 ),
-                              ),
-                              if (widget.showUserAvatar)
-                                Padding(
-                                  padding: EdgeInsets.symmetric(
-                                    horizontal: constraints.maxWidth * 0.02,
+                                if (showPreviousDate)
+                                  DateBuilder(
+                                    date: previousDate,
+                                    customDateBuilder: widget.dateBuilder,
+                                    dateFormat: widget.dateFormat,
                                   ),
-                                  child: Opacity(
-                                    opacity: (widget.showAvatarForEverMessage ||
-                                                showAvatar) &&
-                                            widget.messages[i].user.uid ==
-                                                widget.user.uid
-                                        ? 1
-                                        : 0,
-                                    child: AvatarContainer(
-                                      user: widget.messages[i].user,
-                                      onPress: widget.onPressAvatar,
-                                      onLongPress: widget.onLongPressAvatar,
-                                      avatarBuilder: widget.avatarBuilder,
-                                      avatarMaxSize: widget.avatarMaxSize,
-                                    ),
-                                  ),
-                                )
-                              else
-                                SizedBox(
-                                  width: 10.0,
-                                ),
-                            ],
-                          ),
-                          if (showPreviousDate)
-                            DateBuilder(
-                              date: previousDate,
-                              customDateBuilder: widget.dateBuilder,
-                              dateFormat: widget.dateFormat,
+                              ],
                             ),
-                        ],
+                          );
+                        },
                       ),
-                    );
-                  },
+                      Container(
+                        height: 100.0,
+                      ),
+                      AnimatedPositioned(
+                        top: widget.showLoadMore ? 8.0 : -50.0,
+                        duration: Duration(milliseconds: 200),
+                        child: widget.showLoadEarlierWidget != null
+                            ? widget.showLoadEarlierWidget()
+                            : LoadEarlierWidget(
+                                onLoadEarlier: widget.onLoadEarlier,
+                                defaultLoadCallback: widget.defaultLoadCallback,
+                              ),
+                      ),
+                    ],
+                  ),
                 ),
-                Container(
-                  height: 100.0,
-                ),
-                AnimatedPositioned(
-                  top: widget.showLoadMore ? 8.0 : -50.0,
-                  duration: Duration(milliseconds: 200),
-                  child: widget.showLoadEarlierWidget != null
-                      ? widget.showLoadEarlierWidget()
-                      : LoadEarlierWidget(
-                          onLoadEarlier: widget.onLoadEarlier,
-                          defaultLoadCallback: widget.defaultLoadCallback,
-                        ),
-                ),
-              ],
+              ),
             ),
-          ),
+          ],
         ),
       ),
     );

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -123,255 +123,241 @@ class _MessageListViewState extends State<MessageListView> {
             maxHeight: MediaQuery.of(context).size.height,
             maxWidth: MediaQuery.of(context).size.width);
     final itemCount = widget.messages.length;
-    return IntrinsicHeight(
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Container(
-            color: Colors.red,
-            child: GestureDetector(
-              onTap: () {
-                final currentFocus = FocusScope.of(context);
-                if (!currentFocus.hasPrimaryFocus && currentFocus.hasFocus) {
-                  FocusManager.instance.primaryFocus.unfocus();
-                }
-              },
-              child: Padding(
-                padding: widget.messageContainerPadding,
-                child: NotificationListener<ScrollNotification>(
-                  onNotification: scrollNotificationFunc,
-                  child: Stack(
-                    alignment: AlignmentDirectional.topCenter,
-                    children: [
-                      ListView.builder(
-                        controller: widget.scrollController,
-                        physics: widget.scrollPhysics,
-                        keyboardDismissBehavior:
-                            ScrollViewKeyboardDismissBehavior.onDrag,
-                        shrinkWrap: true,
-                        reverse: widget.inverted,
-                        itemCount: itemCount,
-                        itemBuilder: (context, i) {
-                          bool showAvatar = shouldShowAvatar(i);
-                          bool first = i == 0;
-                          bool last = i == itemCount - 1;
+    return Flexible(
+      child: Container(
+        color: Colors.red,
+        child: GestureDetector(
+          onTap: () {
+            final currentFocus = FocusScope.of(context);
+            if (!currentFocus.hasPrimaryFocus && currentFocus.hasFocus) {
+              FocusManager.instance.primaryFocus.unfocus();
+            }
+          },
+          child: Padding(
+            padding: widget.messageContainerPadding,
+            child: NotificationListener<ScrollNotification>(
+              onNotification: scrollNotificationFunc,
+              child: Stack(
+                alignment: AlignmentDirectional.topCenter,
+                children: [
+                  ListView.builder(
+                    controller: widget.scrollController,
+                    physics: widget.scrollPhysics,
+                    keyboardDismissBehavior:
+                        ScrollViewKeyboardDismissBehavior.onDrag,
+                    shrinkWrap: true,
+                    reverse: widget.inverted,
+                    itemCount: itemCount,
+                    itemBuilder: (context, i) {
+                      bool showAvatar = shouldShowAvatar(i);
+                      bool first = i == 0;
+                      bool last = i == itemCount - 1;
 
-                          DateTime currentDate = DateTime(
-                            widget.messages[i].createdAt.year,
-                            widget.messages[i].createdAt.month,
-                            widget.messages[i].createdAt.day,
-                          );
+                      DateTime currentDate = DateTime(
+                        widget.messages[i].createdAt.year,
+                        widget.messages[i].createdAt.month,
+                        widget.messages[i].createdAt.day,
+                      );
 
-                          DateTime previousDate;
-                          if (i == 0) {
-                            previousDate = currentDate;
-                          } else {
-                            previousDate = DateTime(
-                              widget.messages[i - 1].createdAt.year,
-                              widget.messages[i - 1].createdAt.month,
-                              widget.messages[i - 1].createdAt.day,
-                            );
-                          }
-                          bool showCurrentDate = false;
-                          bool showPreviousDate = false;
-                          if (currentDate.difference(previousDate).inDays !=
-                              0) {
-                            if (widget.inverted) {
-                              showPreviousDate = true;
-                              if (last) {
-                                showCurrentDate = true;
-                              }
-                            } else {
-                              showCurrentDate = true;
-                              if (first) {
-                                showPreviousDate = true;
-                              }
-                            }
-                          } else if (widget.inverted && last) {
-                            showCurrentDate = true;
-                          } else if (!widget.inverted && first) {
+                      DateTime previousDate;
+                      if (i == 0) {
+                        previousDate = currentDate;
+                      } else {
+                        previousDate = DateTime(
+                          widget.messages[i - 1].createdAt.year,
+                          widget.messages[i - 1].createdAt.month,
+                          widget.messages[i - 1].createdAt.day,
+                        );
+                      }
+                      bool showCurrentDate = false;
+                      bool showPreviousDate = false;
+                      if (currentDate.difference(previousDate).inDays != 0) {
+                        if (widget.inverted) {
+                          showPreviousDate = true;
+                          if (last) {
                             showCurrentDate = true;
                           }
+                        } else {
+                          showCurrentDate = true;
+                          if (first) {
+                            showPreviousDate = true;
+                          }
+                        }
+                      } else if (widget.inverted && last) {
+                        showCurrentDate = true;
+                      } else if (!widget.inverted && first) {
+                        showCurrentDate = true;
+                      }
 
-                          return Align(
-                            child: Column(
+                      return Align(
+                        child: Column(
+                          children: <Widget>[
+                            if (showCurrentDate)
+                              DateBuilder(
+                                date: currentDate,
+                                customDateBuilder: widget.dateBuilder,
+                                dateFormat: widget.dateFormat,
+                              ),
+                            Row(
+                              mainAxisAlignment:
+                                  widget.messages[i].user.uid == widget.user.uid
+                                      ? MainAxisAlignment.end
+                                      : MainAxisAlignment.start,
+                              crossAxisAlignment: CrossAxisAlignment.end,
                               children: <Widget>[
-                                if (showCurrentDate)
-                                  DateBuilder(
-                                    date: currentDate,
-                                    customDateBuilder: widget.dateBuilder,
-                                    dateFormat: widget.dateFormat,
+                                Padding(
+                                  padding: EdgeInsets.symmetric(
+                                    horizontal: constraints.maxWidth * 0.02,
                                   ),
-                                Row(
-                                  mainAxisAlignment:
-                                      widget.messages[i].user.uid ==
-                                              widget.user.uid
-                                          ? MainAxisAlignment.end
-                                          : MainAxisAlignment.start,
-                                  crossAxisAlignment: CrossAxisAlignment.end,
-                                  children: <Widget>[
-                                    Padding(
-                                      padding: EdgeInsets.symmetric(
-                                        horizontal: constraints.maxWidth * 0.02,
-                                      ),
-                                      child: Opacity(
-                                        opacity:
-                                            (widget.showAvatarForEverMessage ||
-                                                        showAvatar) &&
-                                                    widget.messages[i].user
-                                                            .uid !=
-                                                        widget.user.uid
-                                                ? 1
-                                                : 0,
-                                        child: AvatarContainer(
-                                          user: widget.messages[i].user,
-                                          onPress: widget.onPressAvatar,
-                                          onLongPress: widget.onLongPressAvatar,
-                                          avatarBuilder: widget.avatarBuilder,
-                                          avatarMaxSize: widget.avatarMaxSize,
-                                        ),
-                                      ),
+                                  child: Opacity(
+                                    opacity: (widget.showAvatarForEverMessage ||
+                                                showAvatar) &&
+                                            widget.messages[i].user.uid !=
+                                                widget.user.uid
+                                        ? 1
+                                        : 0,
+                                    child: AvatarContainer(
+                                      user: widget.messages[i].user,
+                                      onPress: widget.onPressAvatar,
+                                      onLongPress: widget.onLongPressAvatar,
+                                      avatarBuilder: widget.avatarBuilder,
+                                      avatarMaxSize: widget.avatarMaxSize,
                                     ),
-                                    Expanded(
-                                      child: GestureDetector(
-                                        onLongPress: () {
-                                          if (widget.onLongPressMessage !=
-                                              null) {
-                                            widget.onLongPressMessage(
-                                                widget.messages[i]);
-                                          } else {
-                                            showBottomSheet(
-                                                context: context,
-                                                builder: (context) => Container(
-                                                      child: Column(
-                                                        mainAxisSize:
-                                                            MainAxisSize.min,
-                                                        children: <Widget>[
-                                                          ListTile(
-                                                            leading: Icon(Icons
-                                                                .content_copy),
-                                                            title: Text(
-                                                                "Copy to clipboard"),
-                                                            onTap: () {
-                                                              Clipboard.setData(
-                                                                  ClipboardData(
-                                                                      text: widget
-                                                                          .messages[
-                                                                              i]
-                                                                          .text));
-                                                              Navigator.pop(
-                                                                  context);
-                                                            },
-                                                          )
-                                                        ],
-                                                      ),
-                                                    ));
-                                          }
-                                        },
-                                        child: widget.messageBuilder != null
-                                            ? widget.messageBuilder(
-                                                widget.messages[i])
-                                            : Align(
-                                                alignment: widget.messages[i]
-                                                            .user.uid ==
-                                                        widget.user.uid
-                                                    ? AlignmentDirectional
-                                                        .centerEnd
-                                                    : AlignmentDirectional
-                                                        .centerStart,
-                                                child: MessageContainer(
-                                                  messagePadding:
-                                                      widget.messagePadding,
-                                                  constraints: constraints,
-                                                  isUser: widget.messages[i]
-                                                          .user.uid ==
-                                                      widget.user.uid,
-                                                  message: widget.messages[i],
-                                                  timeFormat: widget.timeFormat,
-                                                  messageImageBuilder: widget
-                                                      .messageImageBuilder,
-                                                  messageTextBuilder:
-                                                      widget.messageTextBuilder,
-                                                  messageTimeBuilder:
-                                                      widget.messageTimeBuilder,
-                                                  messageContainerDecoration: widget
-                                                      .messageContainerDecoration,
-                                                  parsePatterns:
-                                                      widget.parsePatterns,
-                                                  buttons: widget
-                                                      .messages[i].buttons,
-                                                  messageButtonsBuilder: widget
-                                                      .messageButtonsBuilder,
-                                                  textBeforeImage:
-                                                      widget.textBeforeImage,
-                                                  messageDecorationBuilder: widget
-                                                      .messageDecorationBuilder,
-                                                ),
-                                              ),
-                                      ),
-                                    ),
-                                    if (widget.showUserAvatar)
-                                      Padding(
-                                        padding: EdgeInsets.symmetric(
-                                          horizontal:
-                                              constraints.maxWidth * 0.02,
-                                        ),
-                                        child: Opacity(
-                                          opacity:
-                                              (widget.showAvatarForEverMessage ||
-                                                          showAvatar) &&
-                                                      widget.messages[i].user
-                                                              .uid ==
-                                                          widget.user.uid
-                                                  ? 1
-                                                  : 0,
-                                          child: AvatarContainer(
-                                            user: widget.messages[i].user,
-                                            onPress: widget.onPressAvatar,
-                                            onLongPress:
-                                                widget.onLongPressAvatar,
-                                            avatarBuilder: widget.avatarBuilder,
-                                            avatarMaxSize: widget.avatarMaxSize,
-                                          ),
-                                        ),
-                                      )
-                                    else
-                                      SizedBox(
-                                        width: 10.0,
-                                      ),
-                                  ],
+                                  ),
                                 ),
-                                if (showPreviousDate)
-                                  DateBuilder(
-                                    date: previousDate,
-                                    customDateBuilder: widget.dateBuilder,
-                                    dateFormat: widget.dateFormat,
+                                Expanded(
+                                  child: GestureDetector(
+                                    onLongPress: () {
+                                      if (widget.onLongPressMessage != null) {
+                                        widget.onLongPressMessage(
+                                            widget.messages[i]);
+                                      } else {
+                                        showBottomSheet(
+                                            context: context,
+                                            builder: (context) => Container(
+                                                  child: Column(
+                                                    mainAxisSize:
+                                                        MainAxisSize.min,
+                                                    children: <Widget>[
+                                                      ListTile(
+                                                        leading: Icon(
+                                                            Icons.content_copy),
+                                                        title: Text(
+                                                            "Copy to clipboard"),
+                                                        onTap: () {
+                                                          Clipboard.setData(
+                                                              ClipboardData(
+                                                                  text: widget
+                                                                      .messages[
+                                                                          i]
+                                                                      .text));
+                                                          Navigator.pop(
+                                                              context);
+                                                        },
+                                                      )
+                                                    ],
+                                                  ),
+                                                ));
+                                      }
+                                    },
+                                    child: widget.messageBuilder != null
+                                        ? widget
+                                            .messageBuilder(widget.messages[i])
+                                        : Align(
+                                            alignment: widget
+                                                        .messages[i].user.uid ==
+                                                    widget.user.uid
+                                                ? AlignmentDirectional.centerEnd
+                                                : AlignmentDirectional
+                                                    .centerStart,
+                                            child: MessageContainer(
+                                              messagePadding:
+                                                  widget.messagePadding,
+                                              constraints: constraints,
+                                              isUser:
+                                                  widget.messages[i].user.uid ==
+                                                      widget.user.uid,
+                                              message: widget.messages[i],
+                                              timeFormat: widget.timeFormat,
+                                              messageImageBuilder:
+                                                  widget.messageImageBuilder,
+                                              messageTextBuilder:
+                                                  widget.messageTextBuilder,
+                                              messageTimeBuilder:
+                                                  widget.messageTimeBuilder,
+                                              messageContainerDecoration: widget
+                                                  .messageContainerDecoration,
+                                              parsePatterns:
+                                                  widget.parsePatterns,
+                                              buttons:
+                                                  widget.messages[i].buttons,
+                                              messageButtonsBuilder:
+                                                  widget.messageButtonsBuilder,
+                                              textBeforeImage:
+                                                  widget.textBeforeImage,
+                                              messageDecorationBuilder: widget
+                                                  .messageDecorationBuilder,
+                                            ),
+                                          ),
+                                  ),
+                                ),
+                                if (widget.showUserAvatar)
+                                  Padding(
+                                    padding: EdgeInsets.symmetric(
+                                      horizontal: constraints.maxWidth * 0.02,
+                                    ),
+                                    child: Opacity(
+                                      opacity:
+                                          (widget.showAvatarForEverMessage ||
+                                                      showAvatar) &&
+                                                  widget.messages[i].user.uid ==
+                                                      widget.user.uid
+                                              ? 1
+                                              : 0,
+                                      child: AvatarContainer(
+                                        user: widget.messages[i].user,
+                                        onPress: widget.onPressAvatar,
+                                        onLongPress: widget.onLongPressAvatar,
+                                        avatarBuilder: widget.avatarBuilder,
+                                        avatarMaxSize: widget.avatarMaxSize,
+                                      ),
+                                    ),
+                                  )
+                                else
+                                  SizedBox(
+                                    width: 10.0,
                                   ),
                               ],
                             ),
-                          );
-                        },
-                      ),
-                      Container(
-                        height: 100.0,
-                      ),
-                      AnimatedPositioned(
-                        top: widget.showLoadMore ? 8.0 : -50.0,
-                        duration: Duration(milliseconds: 200),
-                        child: widget.showLoadEarlierWidget != null
-                            ? widget.showLoadEarlierWidget()
-                            : LoadEarlierWidget(
-                                onLoadEarlier: widget.onLoadEarlier,
-                                defaultLoadCallback: widget.defaultLoadCallback,
+                            if (showPreviousDate)
+                              DateBuilder(
+                                date: previousDate,
+                                customDateBuilder: widget.dateBuilder,
+                                dateFormat: widget.dateFormat,
                               ),
-                      ),
-                    ],
+                          ],
+                        ),
+                      );
+                    },
                   ),
-                ),
+                  Container(
+                    height: 100.0,
+                  ),
+                  AnimatedPositioned(
+                    top: widget.showLoadMore ? 8.0 : -50.0,
+                    duration: Duration(milliseconds: 200),
+                    child: widget.showLoadEarlierWidget != null
+                        ? widget.showLoadEarlierWidget()
+                        : LoadEarlierWidget(
+                            onLoadEarlier: widget.onLoadEarlier,
+                            defaultLoadCallback: widget.defaultLoadCallback,
+                          ),
+                  ),
+                ],
               ),
             ),
           ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -124,6 +124,7 @@ class _MessageListViewState extends State<MessageListView> {
             maxWidth: MediaQuery.of(context).size.width);
     final itemCount = widget.messages.length;
     return Flexible(
+      flex: 4,
       child: GestureDetector(
         onTap: () {
           final currentFocus = FocusScope.of(context);

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -140,80 +140,183 @@ class _MessageListViewState extends State<MessageListView> {
               children: [
                 Container(
                   color: Colors.red,
-                  child: IntrinsicHeight(
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        ListView.builder(
-                          controller: widget.scrollController,
-                          physics: widget.scrollPhysics,
-                          keyboardDismissBehavior:
-                              ScrollViewKeyboardDismissBehavior.onDrag,
-                          shrinkWrap: true,
-                          reverse: widget.inverted,
-                          itemCount: itemCount,
-                          itemBuilder: (context, i) {
-                            bool showAvatar = shouldShowAvatar(i);
-                            bool first = i == 0;
-                            bool last = i == itemCount - 1;
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      ListView.builder(
+                        controller: widget.scrollController,
+                        physics: widget.scrollPhysics,
+                        keyboardDismissBehavior:
+                            ScrollViewKeyboardDismissBehavior.onDrag,
+                        shrinkWrap: true,
+                        reverse: widget.inverted,
+                        itemCount: itemCount,
+                        itemBuilder: (context, i) {
+                          bool showAvatar = shouldShowAvatar(i);
+                          bool first = i == 0;
+                          bool last = i == itemCount - 1;
 
-                            DateTime currentDate = DateTime(
-                              widget.messages[i].createdAt.year,
-                              widget.messages[i].createdAt.month,
-                              widget.messages[i].createdAt.day,
+                          DateTime currentDate = DateTime(
+                            widget.messages[i].createdAt.year,
+                            widget.messages[i].createdAt.month,
+                            widget.messages[i].createdAt.day,
+                          );
+
+                          DateTime previousDate;
+                          if (i == 0) {
+                            previousDate = currentDate;
+                          } else {
+                            previousDate = DateTime(
+                              widget.messages[i - 1].createdAt.year,
+                              widget.messages[i - 1].createdAt.month,
+                              widget.messages[i - 1].createdAt.day,
                             );
-
-                            DateTime previousDate;
-                            if (i == 0) {
-                              previousDate = currentDate;
-                            } else {
-                              previousDate = DateTime(
-                                widget.messages[i - 1].createdAt.year,
-                                widget.messages[i - 1].createdAt.month,
-                                widget.messages[i - 1].createdAt.day,
-                              );
-                            }
-                            bool showCurrentDate = false;
-                            bool showPreviousDate = false;
-                            if (currentDate.difference(previousDate).inDays !=
-                                0) {
-                              if (widget.inverted) {
-                                showPreviousDate = true;
-                                if (last) {
-                                  showCurrentDate = true;
-                                }
-                              } else {
+                          }
+                          bool showCurrentDate = false;
+                          bool showPreviousDate = false;
+                          if (currentDate.difference(previousDate).inDays !=
+                              0) {
+                            if (widget.inverted) {
+                              showPreviousDate = true;
+                              if (last) {
                                 showCurrentDate = true;
-                                if (first) {
-                                  showPreviousDate = true;
-                                }
                               }
-                            } else if (widget.inverted && last) {
+                            } else {
                               showCurrentDate = true;
-                            } else if (!widget.inverted && first) {
-                              showCurrentDate = true;
+                              if (first) {
+                                showPreviousDate = true;
+                              }
                             }
+                          } else if (widget.inverted && last) {
+                            showCurrentDate = true;
+                          } else if (!widget.inverted && first) {
+                            showCurrentDate = true;
+                          }
 
-                            return Container(
-                              color: Colors.blue,
-                              child: Align(
-                                child: Column(
-                                  children: <Widget>[
-                                    if (showCurrentDate)
-                                      DateBuilder(
-                                        date: currentDate,
-                                        customDateBuilder: widget.dateBuilder,
-                                        dateFormat: widget.dateFormat,
+                          return Container(
+                            color: Colors.blue,
+                            child: Align(
+                              child: Column(
+                                children: <Widget>[
+                                  if (showCurrentDate)
+                                    DateBuilder(
+                                      date: currentDate,
+                                      customDateBuilder: widget.dateBuilder,
+                                      dateFormat: widget.dateFormat,
+                                    ),
+                                  Row(
+                                    mainAxisAlignment:
+                                        widget.messages[i].user.uid ==
+                                                widget.user.uid
+                                            ? MainAxisAlignment.end
+                                            : MainAxisAlignment.start,
+                                    crossAxisAlignment: CrossAxisAlignment.end,
+                                    children: <Widget>[
+                                      Padding(
+                                        padding: EdgeInsets.symmetric(
+                                          horizontal:
+                                              constraints.maxWidth * 0.02,
+                                        ),
+                                        child: Opacity(
+                                          opacity:
+                                              (widget.showAvatarForEverMessage ||
+                                                          showAvatar) &&
+                                                      widget.messages[i].user
+                                                              .uid !=
+                                                          widget.user.uid
+                                                  ? 1
+                                                  : 0,
+                                          child: AvatarContainer(
+                                            user: widget.messages[i].user,
+                                            onPress: widget.onPressAvatar,
+                                            onLongPress:
+                                                widget.onLongPressAvatar,
+                                            avatarBuilder: widget.avatarBuilder,
+                                            avatarMaxSize: widget.avatarMaxSize,
+                                          ),
+                                        ),
                                       ),
-                                    Row(
-                                      mainAxisAlignment:
-                                          widget.messages[i].user.uid ==
-                                                  widget.user.uid
-                                              ? MainAxisAlignment.end
-                                              : MainAxisAlignment.start,
-                                      crossAxisAlignment:
-                                          CrossAxisAlignment.end,
-                                      children: <Widget>[
+                                      Expanded(
+                                        child: GestureDetector(
+                                          onLongPress: () {
+                                            if (widget.onLongPressMessage !=
+                                                null) {
+                                              widget.onLongPressMessage(
+                                                  widget.messages[i]);
+                                            } else {
+                                              showBottomSheet(
+                                                  context: context,
+                                                  builder: (context) =>
+                                                      Container(
+                                                        child: Column(
+                                                          mainAxisSize:
+                                                              MainAxisSize.min,
+                                                          children: <Widget>[
+                                                            ListTile(
+                                                              leading: Icon(Icons
+                                                                  .content_copy),
+                                                              title: Text(
+                                                                  "Copy to clipboard"),
+                                                              onTap: () {
+                                                                Clipboard.setData(ClipboardData(
+                                                                    text: widget
+                                                                        .messages[
+                                                                            i]
+                                                                        .text));
+                                                                Navigator.pop(
+                                                                    context);
+                                                              },
+                                                            )
+                                                          ],
+                                                        ),
+                                                      ));
+                                            }
+                                          },
+                                          child: widget.messageBuilder != null
+                                              ? widget.messageBuilder(
+                                                  widget.messages[i])
+                                              : Align(
+                                                  alignment: widget.messages[i]
+                                                              .user.uid ==
+                                                          widget.user.uid
+                                                      ? AlignmentDirectional
+                                                          .centerEnd
+                                                      : AlignmentDirectional
+                                                          .centerStart,
+                                                  child: MessageContainer(
+                                                    messagePadding:
+                                                        widget.messagePadding,
+                                                    constraints: constraints,
+                                                    isUser: widget.messages[i]
+                                                            .user.uid ==
+                                                        widget.user.uid,
+                                                    message: widget.messages[i],
+                                                    timeFormat:
+                                                        widget.timeFormat,
+                                                    messageImageBuilder: widget
+                                                        .messageImageBuilder,
+                                                    messageTextBuilder: widget
+                                                        .messageTextBuilder,
+                                                    messageTimeBuilder: widget
+                                                        .messageTimeBuilder,
+                                                    messageContainerDecoration:
+                                                        widget
+                                                            .messageContainerDecoration,
+                                                    parsePatterns:
+                                                        widget.parsePatterns,
+                                                    buttons: widget
+                                                        .messages[i].buttons,
+                                                    messageButtonsBuilder: widget
+                                                        .messageButtonsBuilder,
+                                                    textBeforeImage:
+                                                        widget.textBeforeImage,
+                                                    messageDecorationBuilder: widget
+                                                        .messageDecorationBuilder,
+                                                  ),
+                                                ),
+                                        ),
+                                      ),
+                                      if (widget.showUserAvatar)
                                         Padding(
                                           padding: EdgeInsets.symmetric(
                                             horizontal:
@@ -224,7 +327,7 @@ class _MessageListViewState extends State<MessageListView> {
                                                 (widget.showAvatarForEverMessage ||
                                                             showAvatar) &&
                                                         widget.messages[i].user
-                                                                .uid !=
+                                                                .uid ==
                                                             widget.user.uid
                                                     ? 1
                                                     : 0,
@@ -239,139 +342,26 @@ class _MessageListViewState extends State<MessageListView> {
                                                   widget.avatarMaxSize,
                                             ),
                                           ),
+                                        )
+                                      else
+                                        SizedBox(
+                                          width: 10.0,
                                         ),
-                                        Expanded(
-                                          child: GestureDetector(
-                                            onLongPress: () {
-                                              if (widget.onLongPressMessage !=
-                                                  null) {
-                                                widget.onLongPressMessage(
-                                                    widget.messages[i]);
-                                              } else {
-                                                showBottomSheet(
-                                                    context: context,
-                                                    builder: (context) =>
-                                                        Container(
-                                                          child: Column(
-                                                            mainAxisSize:
-                                                                MainAxisSize
-                                                                    .min,
-                                                            children: <Widget>[
-                                                              ListTile(
-                                                                leading: Icon(Icons
-                                                                    .content_copy),
-                                                                title: Text(
-                                                                    "Copy to clipboard"),
-                                                                onTap: () {
-                                                                  Clipboard.setData(ClipboardData(
-                                                                      text: widget
-                                                                          .messages[
-                                                                              i]
-                                                                          .text));
-                                                                  Navigator.pop(
-                                                                      context);
-                                                                },
-                                                              )
-                                                            ],
-                                                          ),
-                                                        ));
-                                              }
-                                            },
-                                            child: widget.messageBuilder != null
-                                                ? widget.messageBuilder(
-                                                    widget.messages[i])
-                                                : Align(
-                                                    alignment: widget
-                                                                .messages[i]
-                                                                .user
-                                                                .uid ==
-                                                            widget.user.uid
-                                                        ? AlignmentDirectional
-                                                            .centerEnd
-                                                        : AlignmentDirectional
-                                                            .centerStart,
-                                                    child: MessageContainer(
-                                                      messagePadding:
-                                                          widget.messagePadding,
-                                                      constraints: constraints,
-                                                      isUser: widget.messages[i]
-                                                              .user.uid ==
-                                                          widget.user.uid,
-                                                      message:
-                                                          widget.messages[i],
-                                                      timeFormat:
-                                                          widget.timeFormat,
-                                                      messageImageBuilder: widget
-                                                          .messageImageBuilder,
-                                                      messageTextBuilder: widget
-                                                          .messageTextBuilder,
-                                                      messageTimeBuilder: widget
-                                                          .messageTimeBuilder,
-                                                      messageContainerDecoration:
-                                                          widget
-                                                              .messageContainerDecoration,
-                                                      parsePatterns:
-                                                          widget.parsePatterns,
-                                                      buttons: widget
-                                                          .messages[i].buttons,
-                                                      messageButtonsBuilder: widget
-                                                          .messageButtonsBuilder,
-                                                      textBeforeImage: widget
-                                                          .textBeforeImage,
-                                                      messageDecorationBuilder:
-                                                          widget
-                                                              .messageDecorationBuilder,
-                                                    ),
-                                                  ),
-                                          ),
-                                        ),
-                                        if (widget.showUserAvatar)
-                                          Padding(
-                                            padding: EdgeInsets.symmetric(
-                                              horizontal:
-                                                  constraints.maxWidth * 0.02,
-                                            ),
-                                            child: Opacity(
-                                              opacity:
-                                                  (widget.showAvatarForEverMessage ||
-                                                              showAvatar) &&
-                                                          widget.messages[i]
-                                                                  .user.uid ==
-                                                              widget.user.uid
-                                                      ? 1
-                                                      : 0,
-                                              child: AvatarContainer(
-                                                user: widget.messages[i].user,
-                                                onPress: widget.onPressAvatar,
-                                                onLongPress:
-                                                    widget.onLongPressAvatar,
-                                                avatarBuilder:
-                                                    widget.avatarBuilder,
-                                                avatarMaxSize:
-                                                    widget.avatarMaxSize,
-                                              ),
-                                            ),
-                                          )
-                                        else
-                                          SizedBox(
-                                            width: 10.0,
-                                          ),
-                                      ],
+                                    ],
+                                  ),
+                                  if (showPreviousDate)
+                                    DateBuilder(
+                                      date: previousDate,
+                                      customDateBuilder: widget.dateBuilder,
+                                      dateFormat: widget.dateFormat,
                                     ),
-                                    if (showPreviousDate)
-                                      DateBuilder(
-                                        date: previousDate,
-                                        customDateBuilder: widget.dateBuilder,
-                                        dateFormat: widget.dateFormat,
-                                      ),
-                                  ],
-                                ),
+                                ],
                               ),
-                            );
-                          },
-                        ),
-                      ],
-                    ),
+                            ),
+                          );
+                        },
+                      ),
+                    ],
                   ),
                 ),
                 Container(

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -139,215 +139,200 @@ class _MessageListViewState extends State<MessageListView> {
             child: Stack(
               alignment: AlignmentDirectional.topCenter,
               children: [
-                Container(
-                  color: Colors.red,
-                  child: ListView.builder(
-                    controller: widget.scrollController,
-                    physics: widget.scrollPhysics,
-                    keyboardDismissBehavior:
-                        ScrollViewKeyboardDismissBehavior.onDrag,
-                    shrinkWrap: true,
-                    reverse: widget.inverted,
-                    itemCount: itemCount,
-                    itemBuilder: (context, i) {
-                      bool showAvatar = shouldShowAvatar(i);
-                      bool first = i == 0;
-                      bool last = i == itemCount - 1;
+                ListView.builder(
+                  controller: widget.scrollController,
+                  physics: widget.scrollPhysics,
+                  keyboardDismissBehavior:
+                      ScrollViewKeyboardDismissBehavior.onDrag,
+                  shrinkWrap: true,
+                  reverse: widget.inverted,
+                  itemCount: itemCount,
+                  itemBuilder: (context, i) {
+                    bool showAvatar = shouldShowAvatar(i);
+                    bool first = i == 0;
+                    bool last = i == itemCount - 1;
 
-                      DateTime currentDate = DateTime(
-                        widget.messages[i].createdAt.year,
-                        widget.messages[i].createdAt.month,
-                        widget.messages[i].createdAt.day,
+                    DateTime currentDate = DateTime(
+                      widget.messages[i].createdAt.year,
+                      widget.messages[i].createdAt.month,
+                      widget.messages[i].createdAt.day,
+                    );
+
+                    DateTime previousDate;
+                    if (i == 0) {
+                      previousDate = currentDate;
+                    } else {
+                      previousDate = DateTime(
+                        widget.messages[i - 1].createdAt.year,
+                        widget.messages[i - 1].createdAt.month,
+                        widget.messages[i - 1].createdAt.day,
                       );
-
-                      DateTime previousDate;
-                      if (i == 0) {
-                        previousDate = currentDate;
-                      } else {
-                        previousDate = DateTime(
-                          widget.messages[i - 1].createdAt.year,
-                          widget.messages[i - 1].createdAt.month,
-                          widget.messages[i - 1].createdAt.day,
-                        );
-                      }
-                      bool showCurrentDate = false;
-                      bool showPreviousDate = false;
-                      if (currentDate.difference(previousDate).inDays != 0) {
-                        if (widget.inverted) {
-                          showPreviousDate = true;
-                          if (last) {
-                            showCurrentDate = true;
-                          }
-                        } else {
+                    }
+                    bool showCurrentDate = false;
+                    bool showPreviousDate = false;
+                    if (currentDate.difference(previousDate).inDays != 0) {
+                      if (widget.inverted) {
+                        showPreviousDate = true;
+                        if (last) {
                           showCurrentDate = true;
-                          if (first) {
-                            showPreviousDate = true;
-                          }
                         }
-                      } else if (widget.inverted && last) {
+                      } else {
                         showCurrentDate = true;
-                      } else if (!widget.inverted && first) {
-                        showCurrentDate = true;
+                        if (first) {
+                          showPreviousDate = true;
+                        }
                       }
+                    } else if (widget.inverted && last) {
+                      showCurrentDate = true;
+                    } else if (!widget.inverted && first) {
+                      showCurrentDate = true;
+                    }
 
-                      return Container(
-                        color: Colors.blue,
-                        child: Align(
-                          child: Column(
+                    return Align(
+                      child: Column(
+                        children: <Widget>[
+                          if (showCurrentDate)
+                            DateBuilder(
+                              date: currentDate,
+                              customDateBuilder: widget.dateBuilder,
+                              dateFormat: widget.dateFormat,
+                            ),
+                          Row(
+                            mainAxisAlignment:
+                                widget.messages[i].user.uid == widget.user.uid
+                                    ? MainAxisAlignment.end
+                                    : MainAxisAlignment.start,
+                            crossAxisAlignment: CrossAxisAlignment.end,
                             children: <Widget>[
-                              if (showCurrentDate)
-                                DateBuilder(
-                                  date: currentDate,
-                                  customDateBuilder: widget.dateBuilder,
-                                  dateFormat: widget.dateFormat,
+                              Padding(
+                                padding: EdgeInsets.symmetric(
+                                  horizontal: constraints.maxWidth * 0.02,
                                 ),
-                              Row(
-                                mainAxisAlignment:
-                                    widget.messages[i].user.uid ==
-                                            widget.user.uid
-                                        ? MainAxisAlignment.end
-                                        : MainAxisAlignment.start,
-                                crossAxisAlignment: CrossAxisAlignment.end,
-                                children: <Widget>[
-                                  Padding(
-                                    padding: EdgeInsets.symmetric(
-                                      horizontal: constraints.maxWidth * 0.02,
-                                    ),
-                                    child: Opacity(
-                                      opacity:
-                                          (widget.showAvatarForEverMessage ||
-                                                      showAvatar) &&
-                                                  widget.messages[i].user.uid !=
-                                                      widget.user.uid
-                                              ? 1
-                                              : 0,
-                                      child: AvatarContainer(
-                                        user: widget.messages[i].user,
-                                        onPress: widget.onPressAvatar,
-                                        onLongPress: widget.onLongPressAvatar,
-                                        avatarBuilder: widget.avatarBuilder,
-                                        avatarMaxSize: widget.avatarMaxSize,
-                                      ),
-                                    ),
+                                child: Opacity(
+                                  opacity: (widget.showAvatarForEverMessage ||
+                                              showAvatar) &&
+                                          widget.messages[i].user.uid !=
+                                              widget.user.uid
+                                      ? 1
+                                      : 0,
+                                  child: AvatarContainer(
+                                    user: widget.messages[i].user,
+                                    onPress: widget.onPressAvatar,
+                                    onLongPress: widget.onLongPressAvatar,
+                                    avatarBuilder: widget.avatarBuilder,
+                                    avatarMaxSize: widget.avatarMaxSize,
                                   ),
-                                  Expanded(
-                                    child: GestureDetector(
-                                      onLongPress: () {
-                                        if (widget.onLongPressMessage != null) {
-                                          widget.onLongPressMessage(
-                                              widget.messages[i]);
-                                        } else {
-                                          showBottomSheet(
-                                              context: context,
-                                              builder: (context) => Container(
-                                                    child: Column(
-                                                      mainAxisSize:
-                                                          MainAxisSize.min,
-                                                      children: <Widget>[
-                                                        ListTile(
-                                                          leading: Icon(Icons
-                                                              .content_copy),
-                                                          title: Text(
-                                                              "Copy to clipboard"),
-                                                          onTap: () {
-                                                            Clipboard.setData(
-                                                                ClipboardData(
-                                                                    text: widget
-                                                                        .messages[
-                                                                            i]
-                                                                        .text));
-                                                            Navigator.pop(
-                                                                context);
-                                                          },
-                                                        )
-                                                      ],
-                                                    ),
-                                                  ));
-                                        }
-                                      },
-                                      child: widget.messageBuilder != null
-                                          ? widget.messageBuilder(
-                                              widget.messages[i])
-                                          : Align(
-                                              alignment:
-                                                  widget.messages[i].user.uid ==
-                                                          widget.user.uid
-                                                      ? AlignmentDirectional
-                                                          .centerEnd
-                                                      : AlignmentDirectional
-                                                          .centerStart,
-                                              child: MessageContainer(
-                                                messagePadding:
-                                                    widget.messagePadding,
-                                                constraints: constraints,
-                                                isUser: widget
-                                                        .messages[i].user.uid ==
-                                                    widget.user.uid,
-                                                message: widget.messages[i],
-                                                timeFormat: widget.timeFormat,
-                                                messageImageBuilder:
-                                                    widget.messageImageBuilder,
-                                                messageTextBuilder:
-                                                    widget.messageTextBuilder,
-                                                messageTimeBuilder:
-                                                    widget.messageTimeBuilder,
-                                                messageContainerDecoration: widget
-                                                    .messageContainerDecoration,
-                                                parsePatterns:
-                                                    widget.parsePatterns,
-                                                buttons:
-                                                    widget.messages[i].buttons,
-                                                messageButtonsBuilder: widget
-                                                    .messageButtonsBuilder,
-                                                textBeforeImage:
-                                                    widget.textBeforeImage,
-                                                messageDecorationBuilder: widget
-                                                    .messageDecorationBuilder,
-                                              ),
-                                            ),
-                                    ),
-                                  ),
-                                  if (widget.showUserAvatar)
-                                    Padding(
-                                      padding: EdgeInsets.symmetric(
-                                        horizontal: constraints.maxWidth * 0.02,
-                                      ),
-                                      child: Opacity(
-                                        opacity:
-                                            (widget.showAvatarForEverMessage ||
-                                                        showAvatar) &&
-                                                    widget.messages[i].user
-                                                            .uid ==
-                                                        widget.user.uid
-                                                ? 1
-                                                : 0,
-                                        child: AvatarContainer(
-                                          user: widget.messages[i].user,
-                                          onPress: widget.onPressAvatar,
-                                          onLongPress: widget.onLongPressAvatar,
-                                          avatarBuilder: widget.avatarBuilder,
-                                          avatarMaxSize: widget.avatarMaxSize,
-                                        ),
-                                      ),
-                                    )
-                                  else
-                                    SizedBox(
-                                      width: 10.0,
-                                    ),
-                                ],
+                                ),
                               ),
-                              if (showPreviousDate)
-                                DateBuilder(
-                                  date: previousDate,
-                                  customDateBuilder: widget.dateBuilder,
-                                  dateFormat: widget.dateFormat,
+                              Expanded(
+                                child: GestureDetector(
+                                  onLongPress: () {
+                                    if (widget.onLongPressMessage != null) {
+                                      widget.onLongPressMessage(
+                                          widget.messages[i]);
+                                    } else {
+                                      showBottomSheet(
+                                          context: context,
+                                          builder: (context) => Container(
+                                                child: Column(
+                                                  mainAxisSize:
+                                                      MainAxisSize.min,
+                                                  children: <Widget>[
+                                                    ListTile(
+                                                      leading: Icon(
+                                                          Icons.content_copy),
+                                                      title: Text(
+                                                          "Copy to clipboard"),
+                                                      onTap: () {
+                                                        Clipboard.setData(
+                                                            ClipboardData(
+                                                                text: widget
+                                                                    .messages[i]
+                                                                    .text));
+                                                        Navigator.pop(context);
+                                                      },
+                                                    )
+                                                  ],
+                                                ),
+                                              ));
+                                    }
+                                  },
+                                  child: widget.messageBuilder != null
+                                      ? widget
+                                          .messageBuilder(widget.messages[i])
+                                      : Align(
+                                          alignment: widget
+                                                      .messages[i].user.uid ==
+                                                  widget.user.uid
+                                              ? AlignmentDirectional.centerEnd
+                                              : AlignmentDirectional
+                                                  .centerStart,
+                                          child: MessageContainer(
+                                            messagePadding:
+                                                widget.messagePadding,
+                                            constraints: constraints,
+                                            isUser:
+                                                widget.messages[i].user.uid ==
+                                                    widget.user.uid,
+                                            message: widget.messages[i],
+                                            timeFormat: widget.timeFormat,
+                                            messageImageBuilder:
+                                                widget.messageImageBuilder,
+                                            messageTextBuilder:
+                                                widget.messageTextBuilder,
+                                            messageTimeBuilder:
+                                                widget.messageTimeBuilder,
+                                            messageContainerDecoration: widget
+                                                .messageContainerDecoration,
+                                            parsePatterns: widget.parsePatterns,
+                                            buttons: widget.messages[i].buttons,
+                                            messageButtonsBuilder:
+                                                widget.messageButtonsBuilder,
+                                            textBeforeImage:
+                                                widget.textBeforeImage,
+                                            messageDecorationBuilder:
+                                                widget.messageDecorationBuilder,
+                                          ),
+                                        ),
+                                ),
+                              ),
+                              if (widget.showUserAvatar)
+                                Padding(
+                                  padding: EdgeInsets.symmetric(
+                                    horizontal: constraints.maxWidth * 0.02,
+                                  ),
+                                  child: Opacity(
+                                    opacity: (widget.showAvatarForEverMessage ||
+                                                showAvatar) &&
+                                            widget.messages[i].user.uid ==
+                                                widget.user.uid
+                                        ? 1
+                                        : 0,
+                                    child: AvatarContainer(
+                                      user: widget.messages[i].user,
+                                      onPress: widget.onPressAvatar,
+                                      onLongPress: widget.onLongPressAvatar,
+                                      avatarBuilder: widget.avatarBuilder,
+                                      avatarMaxSize: widget.avatarMaxSize,
+                                    ),
+                                  ),
+                                )
+                              else
+                                SizedBox(
+                                  width: 10.0,
                                 ),
                             ],
                           ),
-                        ),
-                      );
-                    },
-                  ),
+                          if (showPreviousDate)
+                            DateBuilder(
+                              date: previousDate,
+                              customDateBuilder: widget.dateBuilder,
+                              dateFormat: widget.dateFormat,
+                            ),
+                        ],
+                      ),
+                    );
+                  },
                 ),
                 Container(
                   height: 100.0,

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -140,228 +140,212 @@ class _MessageListViewState extends State<MessageListView> {
               children: [
                 Container(
                   color: Colors.red,
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      ListView.builder(
-                        controller: widget.scrollController,
-                        physics: widget.scrollPhysics,
-                        keyboardDismissBehavior:
-                            ScrollViewKeyboardDismissBehavior.onDrag,
-                        shrinkWrap: true,
-                        reverse: widget.inverted,
-                        itemCount: itemCount,
-                        itemBuilder: (context, i) {
-                          bool showAvatar = shouldShowAvatar(i);
-                          bool first = i == 0;
-                          bool last = i == itemCount - 1;
+                  child: ListView.builder(
+                    controller: widget.scrollController,
+                    physics: widget.scrollPhysics,
+                    keyboardDismissBehavior:
+                        ScrollViewKeyboardDismissBehavior.onDrag,
+                    shrinkWrap: true,
+                    reverse: widget.inverted,
+                    itemCount: itemCount,
+                    itemBuilder: (context, i) {
+                      bool showAvatar = shouldShowAvatar(i);
+                      bool first = i == 0;
+                      bool last = i == itemCount - 1;
 
-                          DateTime currentDate = DateTime(
-                            widget.messages[i].createdAt.year,
-                            widget.messages[i].createdAt.month,
-                            widget.messages[i].createdAt.day,
-                          );
+                      DateTime currentDate = DateTime(
+                        widget.messages[i].createdAt.year,
+                        widget.messages[i].createdAt.month,
+                        widget.messages[i].createdAt.day,
+                      );
 
-                          DateTime previousDate;
-                          if (i == 0) {
-                            previousDate = currentDate;
-                          } else {
-                            previousDate = DateTime(
-                              widget.messages[i - 1].createdAt.year,
-                              widget.messages[i - 1].createdAt.month,
-                              widget.messages[i - 1].createdAt.day,
-                            );
-                          }
-                          bool showCurrentDate = false;
-                          bool showPreviousDate = false;
-                          if (currentDate.difference(previousDate).inDays !=
-                              0) {
-                            if (widget.inverted) {
-                              showPreviousDate = true;
-                              if (last) {
-                                showCurrentDate = true;
-                              }
-                            } else {
-                              showCurrentDate = true;
-                              if (first) {
-                                showPreviousDate = true;
-                              }
-                            }
-                          } else if (widget.inverted && last) {
-                            showCurrentDate = true;
-                          } else if (!widget.inverted && first) {
+                      DateTime previousDate;
+                      if (i == 0) {
+                        previousDate = currentDate;
+                      } else {
+                        previousDate = DateTime(
+                          widget.messages[i - 1].createdAt.year,
+                          widget.messages[i - 1].createdAt.month,
+                          widget.messages[i - 1].createdAt.day,
+                        );
+                      }
+                      bool showCurrentDate = false;
+                      bool showPreviousDate = false;
+                      if (currentDate.difference(previousDate).inDays != 0) {
+                        if (widget.inverted) {
+                          showPreviousDate = true;
+                          if (last) {
                             showCurrentDate = true;
                           }
+                        } else {
+                          showCurrentDate = true;
+                          if (first) {
+                            showPreviousDate = true;
+                          }
+                        }
+                      } else if (widget.inverted && last) {
+                        showCurrentDate = true;
+                      } else if (!widget.inverted && first) {
+                        showCurrentDate = true;
+                      }
 
-                          return Container(
-                            color: Colors.blue,
-                            child: Align(
-                              child: Column(
+                      return Container(
+                        color: Colors.blue,
+                        child: Align(
+                          child: Column(
+                            children: <Widget>[
+                              if (showCurrentDate)
+                                DateBuilder(
+                                  date: currentDate,
+                                  customDateBuilder: widget.dateBuilder,
+                                  dateFormat: widget.dateFormat,
+                                ),
+                              Row(
+                                mainAxisAlignment:
+                                    widget.messages[i].user.uid ==
+                                            widget.user.uid
+                                        ? MainAxisAlignment.end
+                                        : MainAxisAlignment.start,
+                                crossAxisAlignment: CrossAxisAlignment.end,
                                 children: <Widget>[
-                                  if (showCurrentDate)
-                                    DateBuilder(
-                                      date: currentDate,
-                                      customDateBuilder: widget.dateBuilder,
-                                      dateFormat: widget.dateFormat,
+                                  Padding(
+                                    padding: EdgeInsets.symmetric(
+                                      horizontal: constraints.maxWidth * 0.02,
                                     ),
-                                  Row(
-                                    mainAxisAlignment:
-                                        widget.messages[i].user.uid ==
-                                                widget.user.uid
-                                            ? MainAxisAlignment.end
-                                            : MainAxisAlignment.start,
-                                    crossAxisAlignment: CrossAxisAlignment.end,
-                                    children: <Widget>[
-                                      Padding(
-                                        padding: EdgeInsets.symmetric(
-                                          horizontal:
-                                              constraints.maxWidth * 0.02,
-                                        ),
-                                        child: Opacity(
-                                          opacity:
-                                              (widget.showAvatarForEverMessage ||
-                                                          showAvatar) &&
-                                                      widget.messages[i].user
-                                                              .uid !=
-                                                          widget.user.uid
-                                                  ? 1
-                                                  : 0,
-                                          child: AvatarContainer(
-                                            user: widget.messages[i].user,
-                                            onPress: widget.onPressAvatar,
-                                            onLongPress:
-                                                widget.onLongPressAvatar,
-                                            avatarBuilder: widget.avatarBuilder,
-                                            avatarMaxSize: widget.avatarMaxSize,
-                                          ),
-                                        ),
+                                    child: Opacity(
+                                      opacity:
+                                          (widget.showAvatarForEverMessage ||
+                                                      showAvatar) &&
+                                                  widget.messages[i].user.uid !=
+                                                      widget.user.uid
+                                              ? 1
+                                              : 0,
+                                      child: AvatarContainer(
+                                        user: widget.messages[i].user,
+                                        onPress: widget.onPressAvatar,
+                                        onLongPress: widget.onLongPressAvatar,
+                                        avatarBuilder: widget.avatarBuilder,
+                                        avatarMaxSize: widget.avatarMaxSize,
                                       ),
-                                      Expanded(
-                                        child: GestureDetector(
-                                          onLongPress: () {
-                                            if (widget.onLongPressMessage !=
-                                                null) {
-                                              widget.onLongPressMessage(
-                                                  widget.messages[i]);
-                                            } else {
-                                              showBottomSheet(
-                                                  context: context,
-                                                  builder: (context) =>
-                                                      Container(
-                                                        child: Column(
-                                                          mainAxisSize:
-                                                              MainAxisSize.min,
-                                                          children: <Widget>[
-                                                            ListTile(
-                                                              leading: Icon(Icons
-                                                                  .content_copy),
-                                                              title: Text(
-                                                                  "Copy to clipboard"),
-                                                              onTap: () {
-                                                                Clipboard.setData(ClipboardData(
+                                    ),
+                                  ),
+                                  Expanded(
+                                    child: GestureDetector(
+                                      onLongPress: () {
+                                        if (widget.onLongPressMessage != null) {
+                                          widget.onLongPressMessage(
+                                              widget.messages[i]);
+                                        } else {
+                                          showBottomSheet(
+                                              context: context,
+                                              builder: (context) => Container(
+                                                    child: Column(
+                                                      mainAxisSize:
+                                                          MainAxisSize.min,
+                                                      children: <Widget>[
+                                                        ListTile(
+                                                          leading: Icon(Icons
+                                                              .content_copy),
+                                                          title: Text(
+                                                              "Copy to clipboard"),
+                                                          onTap: () {
+                                                            Clipboard.setData(
+                                                                ClipboardData(
                                                                     text: widget
                                                                         .messages[
                                                                             i]
                                                                         .text));
-                                                                Navigator.pop(
-                                                                    context);
-                                                              },
-                                                            )
-                                                          ],
-                                                        ),
-                                                      ));
-                                            }
-                                          },
-                                          child: widget.messageBuilder != null
-                                              ? widget.messageBuilder(
-                                                  widget.messages[i])
-                                              : Align(
-                                                  alignment: widget.messages[i]
-                                                              .user.uid ==
+                                                            Navigator.pop(
+                                                                context);
+                                                          },
+                                                        )
+                                                      ],
+                                                    ),
+                                                  ));
+                                        }
+                                      },
+                                      child: widget.messageBuilder != null
+                                          ? widget.messageBuilder(
+                                              widget.messages[i])
+                                          : Align(
+                                              alignment:
+                                                  widget.messages[i].user.uid ==
                                                           widget.user.uid
                                                       ? AlignmentDirectional
                                                           .centerEnd
                                                       : AlignmentDirectional
                                                           .centerStart,
-                                                  child: MessageContainer(
-                                                    messagePadding:
-                                                        widget.messagePadding,
-                                                    constraints: constraints,
-                                                    isUser: widget.messages[i]
-                                                            .user.uid ==
-                                                        widget.user.uid,
-                                                    message: widget.messages[i],
-                                                    timeFormat:
-                                                        widget.timeFormat,
-                                                    messageImageBuilder: widget
-                                                        .messageImageBuilder,
-                                                    messageTextBuilder: widget
-                                                        .messageTextBuilder,
-                                                    messageTimeBuilder: widget
-                                                        .messageTimeBuilder,
-                                                    messageContainerDecoration:
-                                                        widget
-                                                            .messageContainerDecoration,
-                                                    parsePatterns:
-                                                        widget.parsePatterns,
-                                                    buttons: widget
-                                                        .messages[i].buttons,
-                                                    messageButtonsBuilder: widget
-                                                        .messageButtonsBuilder,
-                                                    textBeforeImage:
-                                                        widget.textBeforeImage,
-                                                    messageDecorationBuilder: widget
-                                                        .messageDecorationBuilder,
-                                                  ),
-                                                ),
+                                              child: MessageContainer(
+                                                messagePadding:
+                                                    widget.messagePadding,
+                                                constraints: constraints,
+                                                isUser: widget
+                                                        .messages[i].user.uid ==
+                                                    widget.user.uid,
+                                                message: widget.messages[i],
+                                                timeFormat: widget.timeFormat,
+                                                messageImageBuilder:
+                                                    widget.messageImageBuilder,
+                                                messageTextBuilder:
+                                                    widget.messageTextBuilder,
+                                                messageTimeBuilder:
+                                                    widget.messageTimeBuilder,
+                                                messageContainerDecoration: widget
+                                                    .messageContainerDecoration,
+                                                parsePatterns:
+                                                    widget.parsePatterns,
+                                                buttons:
+                                                    widget.messages[i].buttons,
+                                                messageButtonsBuilder: widget
+                                                    .messageButtonsBuilder,
+                                                textBeforeImage:
+                                                    widget.textBeforeImage,
+                                                messageDecorationBuilder: widget
+                                                    .messageDecorationBuilder,
+                                              ),
+                                            ),
+                                    ),
+                                  ),
+                                  if (widget.showUserAvatar)
+                                    Padding(
+                                      padding: EdgeInsets.symmetric(
+                                        horizontal: constraints.maxWidth * 0.02,
+                                      ),
+                                      child: Opacity(
+                                        opacity:
+                                            (widget.showAvatarForEverMessage ||
+                                                        showAvatar) &&
+                                                    widget.messages[i].user
+                                                            .uid ==
+                                                        widget.user.uid
+                                                ? 1
+                                                : 0,
+                                        child: AvatarContainer(
+                                          user: widget.messages[i].user,
+                                          onPress: widget.onPressAvatar,
+                                          onLongPress: widget.onLongPressAvatar,
+                                          avatarBuilder: widget.avatarBuilder,
+                                          avatarMaxSize: widget.avatarMaxSize,
                                         ),
                                       ),
-                                      if (widget.showUserAvatar)
-                                        Padding(
-                                          padding: EdgeInsets.symmetric(
-                                            horizontal:
-                                                constraints.maxWidth * 0.02,
-                                          ),
-                                          child: Opacity(
-                                            opacity:
-                                                (widget.showAvatarForEverMessage ||
-                                                            showAvatar) &&
-                                                        widget.messages[i].user
-                                                                .uid ==
-                                                            widget.user.uid
-                                                    ? 1
-                                                    : 0,
-                                            child: AvatarContainer(
-                                              user: widget.messages[i].user,
-                                              onPress: widget.onPressAvatar,
-                                              onLongPress:
-                                                  widget.onLongPressAvatar,
-                                              avatarBuilder:
-                                                  widget.avatarBuilder,
-                                              avatarMaxSize:
-                                                  widget.avatarMaxSize,
-                                            ),
-                                          ),
-                                        )
-                                      else
-                                        SizedBox(
-                                          width: 10.0,
-                                        ),
-                                    ],
-                                  ),
-                                  if (showPreviousDate)
-                                    DateBuilder(
-                                      date: previousDate,
-                                      customDateBuilder: widget.dateBuilder,
-                                      dateFormat: widget.dateFormat,
+                                    )
+                                  else
+                                    SizedBox(
+                                      width: 10.0,
                                     ),
                                 ],
                               ),
-                            ),
-                          );
-                        },
-                      ),
-                    ],
+                              if (showPreviousDate)
+                                DateBuilder(
+                                  date: previousDate,
+                                  customDateBuilder: widget.dateBuilder,
+                                  dateFormat: widget.dateFormat,
+                                ),
+                            ],
+                          ),
+                        ),
+                      );
+                    },
                   ),
                 ),
                 Container(

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -123,242 +123,256 @@ class _MessageListViewState extends State<MessageListView> {
             maxHeight: MediaQuery.of(context).size.height,
             maxWidth: MediaQuery.of(context).size.width);
     final itemCount = widget.messages.length;
-    return Flexible(
-      child: GestureDetector(
-        onTap: () {
-          final currentFocus = FocusScope.of(context);
-          if (!currentFocus.hasPrimaryFocus && currentFocus.hasFocus) {
-            FocusManager.instance.primaryFocus.unfocus();
-          }
-        },
-        child: Padding(
-          padding: widget.messageContainerPadding,
-          child: NotificationListener<ScrollNotification>(
-            onNotification: scrollNotificationFunc,
-            child: Stack(
-              alignment: AlignmentDirectional.topCenter,
-              children: [
-                Container(
-                  color: Colors.red,
-                  child: ListView.builder(
-                    controller: widget.scrollController,
-                    physics: widget.scrollPhysics,
-                    keyboardDismissBehavior:
-                        ScrollViewKeyboardDismissBehavior.onDrag,
-                    shrinkWrap: false,
-                    reverse: widget.inverted,
-                    itemCount: itemCount,
-                    itemBuilder: (context, i) {
-                      bool showAvatar = shouldShowAvatar(i);
-                      bool first = i == 0;
-                      bool last = i == itemCount - 1;
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      children: [
+        Flexible(
+          child: GestureDetector(
+            onTap: () {
+              final currentFocus = FocusScope.of(context);
+              if (!currentFocus.hasPrimaryFocus && currentFocus.hasFocus) {
+                FocusManager.instance.primaryFocus.unfocus();
+              }
+            },
+            child: Padding(
+              padding: widget.messageContainerPadding,
+              child: NotificationListener<ScrollNotification>(
+                onNotification: scrollNotificationFunc,
+                child: Stack(
+                  alignment: AlignmentDirectional.topCenter,
+                  children: [
+                    Container(
+                      color: Colors.red,
+                      child: ListView.builder(
+                        controller: widget.scrollController,
+                        physics: widget.scrollPhysics,
+                        keyboardDismissBehavior:
+                            ScrollViewKeyboardDismissBehavior.onDrag,
+                        shrinkWrap: false,
+                        reverse: widget.inverted,
+                        itemCount: itemCount,
+                        itemBuilder: (context, i) {
+                          bool showAvatar = shouldShowAvatar(i);
+                          bool first = i == 0;
+                          bool last = i == itemCount - 1;
 
-                      DateTime currentDate = DateTime(
-                        widget.messages[i].createdAt.year,
-                        widget.messages[i].createdAt.month,
-                        widget.messages[i].createdAt.day,
-                      );
+                          DateTime currentDate = DateTime(
+                            widget.messages[i].createdAt.year,
+                            widget.messages[i].createdAt.month,
+                            widget.messages[i].createdAt.day,
+                          );
 
-                      DateTime previousDate;
-                      if (i == 0) {
-                        previousDate = currentDate;
-                      } else {
-                        previousDate = DateTime(
-                          widget.messages[i - 1].createdAt.year,
-                          widget.messages[i - 1].createdAt.month,
-                          widget.messages[i - 1].createdAt.day,
-                        );
-                      }
-                      bool showCurrentDate = false;
-                      bool showPreviousDate = false;
-                      if (currentDate.difference(previousDate).inDays != 0) {
-                        if (widget.inverted) {
-                          showPreviousDate = true;
-                          if (last) {
+                          DateTime previousDate;
+                          if (i == 0) {
+                            previousDate = currentDate;
+                          } else {
+                            previousDate = DateTime(
+                              widget.messages[i - 1].createdAt.year,
+                              widget.messages[i - 1].createdAt.month,
+                              widget.messages[i - 1].createdAt.day,
+                            );
+                          }
+                          bool showCurrentDate = false;
+                          bool showPreviousDate = false;
+                          if (currentDate.difference(previousDate).inDays !=
+                              0) {
+                            if (widget.inverted) {
+                              showPreviousDate = true;
+                              if (last) {
+                                showCurrentDate = true;
+                              }
+                            } else {
+                              showCurrentDate = true;
+                              if (first) {
+                                showPreviousDate = true;
+                              }
+                            }
+                          } else if (widget.inverted && last) {
+                            showCurrentDate = true;
+                          } else if (!widget.inverted && first) {
                             showCurrentDate = true;
                           }
-                        } else {
-                          showCurrentDate = true;
-                          if (first) {
-                            showPreviousDate = true;
-                          }
-                        }
-                      } else if (widget.inverted && last) {
-                        showCurrentDate = true;
-                      } else if (!widget.inverted && first) {
-                        showCurrentDate = true;
-                      }
 
-                      return Align(
-                        child: Column(
-                          children: <Widget>[
-                            if (showCurrentDate)
-                              DateBuilder(
-                                date: currentDate,
-                                customDateBuilder: widget.dateBuilder,
-                                dateFormat: widget.dateFormat,
-                              ),
-                            Row(
-                              mainAxisAlignment:
-                                  widget.messages[i].user.uid == widget.user.uid
-                                      ? MainAxisAlignment.end
-                                      : MainAxisAlignment.start,
-                              crossAxisAlignment: CrossAxisAlignment.end,
+                          return Align(
+                            child: Column(
                               children: <Widget>[
-                                Padding(
-                                  padding: EdgeInsets.symmetric(
-                                    horizontal: constraints.maxWidth * 0.02,
+                                if (showCurrentDate)
+                                  DateBuilder(
+                                    date: currentDate,
+                                    customDateBuilder: widget.dateBuilder,
+                                    dateFormat: widget.dateFormat,
                                   ),
-                                  child: Opacity(
-                                    opacity: (widget.showAvatarForEverMessage ||
-                                                showAvatar) &&
-                                            widget.messages[i].user.uid !=
-                                                widget.user.uid
-                                        ? 1
-                                        : 0,
-                                    child: AvatarContainer(
-                                      user: widget.messages[i].user,
-                                      onPress: widget.onPressAvatar,
-                                      onLongPress: widget.onLongPressAvatar,
-                                      avatarBuilder: widget.avatarBuilder,
-                                      avatarMaxSize: widget.avatarMaxSize,
-                                    ),
-                                  ),
-                                ),
-                                Expanded(
-                                  child: GestureDetector(
-                                    onLongPress: () {
-                                      if (widget.onLongPressMessage != null) {
-                                        widget.onLongPressMessage(
-                                            widget.messages[i]);
-                                      } else {
-                                        showBottomSheet(
-                                            context: context,
-                                            builder: (context) => Container(
-                                                  child: Column(
-                                                    mainAxisSize:
-                                                        MainAxisSize.min,
-                                                    children: <Widget>[
-                                                      ListTile(
-                                                        leading: Icon(
-                                                            Icons.content_copy),
-                                                        title: Text(
-                                                            "Copy to clipboard"),
-                                                        onTap: () {
-                                                          Clipboard.setData(
-                                                              ClipboardData(
-                                                                  text: widget
-                                                                      .messages[
-                                                                          i]
-                                                                      .text));
-                                                          Navigator.pop(
-                                                              context);
-                                                        },
-                                                      )
-                                                    ],
-                                                  ),
-                                                ));
-                                      }
-                                    },
-                                    child: widget.messageBuilder != null
-                                        ? widget
-                                            .messageBuilder(widget.messages[i])
-                                        : Align(
-                                            alignment: widget
-                                                        .messages[i].user.uid ==
-                                                    widget.user.uid
-                                                ? AlignmentDirectional.centerEnd
-                                                : AlignmentDirectional
-                                                    .centerStart,
-                                            child: MessageContainer(
-                                              messagePadding:
-                                                  widget.messagePadding,
-                                              constraints: constraints,
-                                              isUser:
-                                                  widget.messages[i].user.uid ==
-                                                      widget.user.uid,
-                                              message: widget.messages[i],
-                                              timeFormat: widget.timeFormat,
-                                              messageImageBuilder:
-                                                  widget.messageImageBuilder,
-                                              messageTextBuilder:
-                                                  widget.messageTextBuilder,
-                                              messageTimeBuilder:
-                                                  widget.messageTimeBuilder,
-                                              messageContainerDecoration: widget
-                                                  .messageContainerDecoration,
-                                              parsePatterns:
-                                                  widget.parsePatterns,
-                                              buttons:
-                                                  widget.messages[i].buttons,
-                                              messageButtonsBuilder:
-                                                  widget.messageButtonsBuilder,
-                                              textBeforeImage:
-                                                  widget.textBeforeImage,
-                                              messageDecorationBuilder: widget
-                                                  .messageDecorationBuilder,
-                                            ),
-                                          ),
-                                  ),
-                                ),
-                                if (widget.showUserAvatar)
-                                  Padding(
-                                    padding: EdgeInsets.symmetric(
-                                      horizontal: constraints.maxWidth * 0.02,
-                                    ),
-                                    child: Opacity(
-                                      opacity:
-                                          (widget.showAvatarForEverMessage ||
-                                                      showAvatar) &&
-                                                  widget.messages[i].user.uid ==
-                                                      widget.user.uid
-                                              ? 1
-                                              : 0,
-                                      child: AvatarContainer(
-                                        user: widget.messages[i].user,
-                                        onPress: widget.onPressAvatar,
-                                        onLongPress: widget.onLongPressAvatar,
-                                        avatarBuilder: widget.avatarBuilder,
-                                        avatarMaxSize: widget.avatarMaxSize,
+                                Row(
+                                  mainAxisAlignment:
+                                      widget.messages[i].user.uid ==
+                                              widget.user.uid
+                                          ? MainAxisAlignment.end
+                                          : MainAxisAlignment.start,
+                                  crossAxisAlignment: CrossAxisAlignment.end,
+                                  children: <Widget>[
+                                    Padding(
+                                      padding: EdgeInsets.symmetric(
+                                        horizontal: constraints.maxWidth * 0.02,
+                                      ),
+                                      child: Opacity(
+                                        opacity:
+                                            (widget.showAvatarForEverMessage ||
+                                                        showAvatar) &&
+                                                    widget.messages[i].user
+                                                            .uid !=
+                                                        widget.user.uid
+                                                ? 1
+                                                : 0,
+                                        child: AvatarContainer(
+                                          user: widget.messages[i].user,
+                                          onPress: widget.onPressAvatar,
+                                          onLongPress: widget.onLongPressAvatar,
+                                          avatarBuilder: widget.avatarBuilder,
+                                          avatarMaxSize: widget.avatarMaxSize,
+                                        ),
                                       ),
                                     ),
-                                  )
-                                else
-                                  SizedBox(
-                                    width: 10.0,
+                                    Expanded(
+                                      child: GestureDetector(
+                                        onLongPress: () {
+                                          if (widget.onLongPressMessage !=
+                                              null) {
+                                            widget.onLongPressMessage(
+                                                widget.messages[i]);
+                                          } else {
+                                            showBottomSheet(
+                                                context: context,
+                                                builder: (context) => Container(
+                                                      child: Column(
+                                                        mainAxisSize:
+                                                            MainAxisSize.min,
+                                                        children: <Widget>[
+                                                          ListTile(
+                                                            leading: Icon(Icons
+                                                                .content_copy),
+                                                            title: Text(
+                                                                "Copy to clipboard"),
+                                                            onTap: () {
+                                                              Clipboard.setData(
+                                                                  ClipboardData(
+                                                                      text: widget
+                                                                          .messages[
+                                                                              i]
+                                                                          .text));
+                                                              Navigator.pop(
+                                                                  context);
+                                                            },
+                                                          )
+                                                        ],
+                                                      ),
+                                                    ));
+                                          }
+                                        },
+                                        child: widget.messageBuilder != null
+                                            ? widget.messageBuilder(
+                                                widget.messages[i])
+                                            : Align(
+                                                alignment: widget.messages[i]
+                                                            .user.uid ==
+                                                        widget.user.uid
+                                                    ? AlignmentDirectional
+                                                        .centerEnd
+                                                    : AlignmentDirectional
+                                                        .centerStart,
+                                                child: MessageContainer(
+                                                  messagePadding:
+                                                      widget.messagePadding,
+                                                  constraints: constraints,
+                                                  isUser: widget.messages[i]
+                                                          .user.uid ==
+                                                      widget.user.uid,
+                                                  message: widget.messages[i],
+                                                  timeFormat: widget.timeFormat,
+                                                  messageImageBuilder: widget
+                                                      .messageImageBuilder,
+                                                  messageTextBuilder:
+                                                      widget.messageTextBuilder,
+                                                  messageTimeBuilder:
+                                                      widget.messageTimeBuilder,
+                                                  messageContainerDecoration: widget
+                                                      .messageContainerDecoration,
+                                                  parsePatterns:
+                                                      widget.parsePatterns,
+                                                  buttons: widget
+                                                      .messages[i].buttons,
+                                                  messageButtonsBuilder: widget
+                                                      .messageButtonsBuilder,
+                                                  textBeforeImage:
+                                                      widget.textBeforeImage,
+                                                  messageDecorationBuilder: widget
+                                                      .messageDecorationBuilder,
+                                                ),
+                                              ),
+                                      ),
+                                    ),
+                                    if (widget.showUserAvatar)
+                                      Padding(
+                                        padding: EdgeInsets.symmetric(
+                                          horizontal:
+                                              constraints.maxWidth * 0.02,
+                                        ),
+                                        child: Opacity(
+                                          opacity:
+                                              (widget.showAvatarForEverMessage ||
+                                                          showAvatar) &&
+                                                      widget.messages[i].user
+                                                              .uid ==
+                                                          widget.user.uid
+                                                  ? 1
+                                                  : 0,
+                                          child: AvatarContainer(
+                                            user: widget.messages[i].user,
+                                            onPress: widget.onPressAvatar,
+                                            onLongPress:
+                                                widget.onLongPressAvatar,
+                                            avatarBuilder: widget.avatarBuilder,
+                                            avatarMaxSize: widget.avatarMaxSize,
+                                          ),
+                                        ),
+                                      )
+                                    else
+                                      SizedBox(
+                                        width: 10.0,
+                                      ),
+                                  ],
+                                ),
+                                if (showPreviousDate)
+                                  DateBuilder(
+                                    date: previousDate,
+                                    customDateBuilder: widget.dateBuilder,
+                                    dateFormat: widget.dateFormat,
                                   ),
                               ],
                             ),
-                            if (showPreviousDate)
-                              DateBuilder(
-                                date: previousDate,
-                                customDateBuilder: widget.dateBuilder,
-                                dateFormat: widget.dateFormat,
-                              ),
-                          ],
-                        ),
-                      );
-                    },
-                  ),
+                          );
+                        },
+                      ),
+                    ),
+                    Container(
+                      height: 100.0,
+                    ),
+                    AnimatedPositioned(
+                      top: widget.showLoadMore ? 8.0 : -50.0,
+                      duration: Duration(milliseconds: 200),
+                      child: widget.showLoadEarlierWidget != null
+                          ? widget.showLoadEarlierWidget()
+                          : LoadEarlierWidget(
+                              onLoadEarlier: widget.onLoadEarlier,
+                              defaultLoadCallback: widget.defaultLoadCallback,
+                            ),
+                    ),
+                  ],
                 ),
-                Container(
-                  height: 100.0,
-                ),
-                AnimatedPositioned(
-                  top: widget.showLoadMore ? 8.0 : -50.0,
-                  duration: Duration(milliseconds: 200),
-                  child: widget.showLoadEarlierWidget != null
-                      ? widget.showLoadEarlierWidget()
-                      : LoadEarlierWidget(
-                          onLoadEarlier: widget.onLoadEarlier,
-                          defaultLoadCallback: widget.defaultLoadCallback,
-                        ),
-                ),
-              ],
+              ),
             ),
           ),
         ),
-      ),
+      ],
     );
   }
 }

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -145,7 +145,7 @@ class _MessageListViewState extends State<MessageListView> {
                     physics: widget.scrollPhysics,
                     keyboardDismissBehavior:
                         ScrollViewKeyboardDismissBehavior.onDrag,
-                    shrinkWrap: true,
+                    shrinkWrap: false,
                     reverse: widget.inverted,
                     itemCount: itemCount,
                     itemBuilder: (context, i) {

--- a/lib/src/message_listview.dart
+++ b/lib/src/message_listview.dart
@@ -12,6 +12,7 @@ class MessageListView extends StatefulWidget {
   final bool renderAvatarOnTop;
   final Function(ChatMessage) onLongPressMessage;
   final bool inverted;
+  final Widget topOfMessagesWidget;
   final Widget Function(ChatUser) avatarBuilder;
   final Widget Function(ChatMessage) messageBuilder;
   final Widget Function(String, [ChatMessage]) messageTextBuilder;
@@ -57,6 +58,7 @@ class MessageListView extends StatefulWidget {
     this.timeFormat,
     this.showAvatarForEverMessage,
     this.inverted,
+    this.topOfMessagesWidget,
     this.onLongPressAvatar,
     this.onLongPressMessage,
     this.onPressAvatar,
@@ -138,18 +140,8 @@ class _MessageListViewState extends State<MessageListView> {
             child: Stack(
               alignment: AlignmentDirectional.topCenter,
               children: [
-                if (itemCount == 0)
-                  Container(
-                    height: 100,
-                    width: constraints.maxWidth,
-                    color: Colors.indigo,
-                    child: Text(
-                      'Image goes here',
-                      style: TextStyle(
-                        color: Colors.white,
-                      ),
-                    ),
-                  ),
+                if (itemCount == 0 && widget.topOfMessagesWidget != null)
+                  widget.topOfMessagesWidget,
                 ListView.builder(
                   controller: widget.scrollController,
                   physics: widget.scrollPhysics,
@@ -202,18 +194,8 @@ class _MessageListViewState extends State<MessageListView> {
                     return Align(
                       child: Column(
                         children: <Widget>[
-                          if (last)
-                            Container(
-                              height: 100,
-                              width: constraints.maxWidth,
-                              color: Colors.indigo,
-                              child: Text(
-                                'Image goes here',
-                                style: TextStyle(
-                                  color: Colors.white,
-                                ),
-                              ),
-                            ),
+                          if (last && widget.topOfMessagesWidget != null)
+                            widget.topOfMessagesWidget,
                           if (showCurrentDate)
                             DateBuilder(
                               date: currentDate,


### PR DESCRIPTION
### Purpose
- [Related to Ch126963](https://app.clubhouse.io/gloo/story/126963/elevate-chat-items)
- [Related to Ch126211](https://app.clubhouse.io/gloo/story/126211/ui-chore-chat-fte)

### Summary
- Adds in a `topOfMessagesWidget` property that we will be able to pass in to the `DashChat(...)` widget from our Spaces app
- This widget will appear above the input field if there are no messages, or it will appear above the first ever sent message
- We need to add this widget in two different places within the tree because `MessageListView` is part of a `Stack`. Thus, it should be shown when there are no messages (since no `MessageListView` will get added), or as part of the `MessageListView` when there are messages. If it is only used as part of the `Stack`, then the widget will show up behind `MessageListView` when there are messages, which is not what we want.